### PR TITLE
Only replace selectedInd if it's undefined (was replacing when 0 too

### DIFF
--- a/src/Dropdown/Dropdown.jsx
+++ b/src/Dropdown/Dropdown.jsx
@@ -78,7 +78,7 @@ const Dropdown = React.createClass({
       initialSelectedInd, selectedInd, data,
       defaultDisplay, className} = this.props;
 
-    selectedInd = selectedInd || initialSelectedInd;
+    selectedInd = selectedInd === undefined ? initialSelectedInd : selectedInd;
 
     const dropdownClasses = cx(
       'dd-open',


### PR DESCRIPTION
This was replacing `selectedInd` when it was equal to `0`. Instead, check if it is `undefined` and then replace