### PR TITLE
Make __env optional for linkSet

### DIFF
--- a/src/AppBar/linkSet.es6
+++ b/src/AppBar/linkSet.es6
@@ -9,11 +9,11 @@ if (global.__env) {
 }
 
 let config = {
-    officeHours: {
+    workshops: {
         icon: 'users'
     },
-    activity: {
-        icon: 'user'
+    library: {
+        icon: 'book'
     }
 }
 if (global.__env) {

--- a/src/AppBar/linkSet.es6
+++ b/src/AppBar/linkSet.es6
@@ -3,18 +3,24 @@ const assign = require('lodash/object/assign');
 const defaults = require('lodash/object/defaults');
 const mapValues = require('lodash/object/mapValues');
 
-let user = global.__env.user;
-let config = {
-    workshops: {
-        icon: 'users'
-    },
-    library: {
-        icon: 'book'
-    }
+let user;
+if (global.__env) {
+    user  = global.__env.user;
 }
 
-config = mapValues(global.__env.config,
-    (link, key) => assign({}, link, config[key]));
+let config = {
+    officeHours: {
+        icon: 'users'
+    },
+    activity: {
+        icon: 'user'
+    }
+}
+if (global.__env) {
+    config = mapValues(
+        global.__env.config,
+        (link, key) => assign({}, link, config[key]));
+}
 
 let home = {displayName: 'Home', icon: 'home'};
 let main = [];


### PR DESCRIPTION
Having a reference to `global.__env.user` in `linkSet` creates a dependency whenever you import something from the root of the `thinkful-ui`. This makes that value optional.