### PR TITLE
Add pathWithSlug/pathWithoutSlug utils for reverse proxied apps

### DIFF
--- a/src/ProxyPathUtils.es6
+++ b/src/ProxyPathUtils.es6
@@ -1,0 +1,24 @@
+
+function pathWithSlug(path) { 
+    var mpath = path;
+    if (window.__env && window.__env.config) {
+        mpath = (window.__env.config.app.slug || '') + path;
+    }
+    return mpath;   
+}
+
+function pathWithoutSlug(path) { 
+    var mpath = path;
+    var slug = '' 
+    if (window.__env && window.__env.config) {
+        slug = window.__env.config.app.slug || '';
+    }
+
+    if (path.indexOf(slug) == 0) {
+        mpath = path.slice(slug.length);   
+    }
+
+    return mpath;   
+}
+
+module.exports = {pathWithSlug, pathWithoutSlug};

--- a/src/index.es6
+++ b/src/index.es6
@@ -10,9 +10,9 @@ const {Loader} = require('./Loader');
 const {Modal} = require('./Modal');
 const {NotificationView} = require('./NotificationView');
 const {OpenSessionOverview} = require('./OpenSessionOverview');
+const {pathWithSlug, pathWithoutSlug} = require('./ProxyPathUtils');
 const {SidebarLayout, SidebarMenu, SidebarMenuItem} = require('./Sidebar');
 const {TrackedLink, AnalyticsAPI} = require('./analytics');
-
 const {models} = require('./models');
 
 module.exports = {
@@ -29,6 +29,7 @@ module.exports = {
   MenuItem: SidebarMenuItem,
   NotificationView,
   OpenSessionOverview,
+  pathWithSlug, pathWithoutSlug,
   SidebarLayout,
   SidebarMenu,
   SidebarMenuItem,


### PR DESCRIPTION
The slug is config.app.slug from the JavaScript __env.  For reverse-proxied apps formerly known as
`appname.thinkful.com` this will be `/appname`

