### PR TITLE
Update babel-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkful-ui",
-  "version": "1.1.49",
+  "version": "1.1.50",
   "description": "Shared navigation and UI resources for Thinkful.",
   "main": "src/index.es6",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   ],
   "dependencies": {
     "autoprefixer-loader": "^2.0.0",
-    "babel-core": "^5.4.7",
+    "babel-core": "^5.8.33",
     "babel-eslint": "^3.1.15",
     "babel-loader": "^5.1.3",
     "babel-runtime": "^5.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkful-ui",
-  "version": "1.1.50",
+  "version": "1.1.51",
   "description": "Shared navigation and UI resources for Thinkful.",
   "main": "src/index.es6",
   "scripts": {


### PR DESCRIPTION
had a bug with using `encodeURIComponent()` inside es6 template strings, and upgrading babel-core was the fix.

The '/' in `${encodeURIComponent('https://something.com')}` were incorrectly coded.