### PR TITLE
check if user is active in overview

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkful-ui",
-  "version": "1.1.56",
+  "version": "1.1.57",
   "description": "Shared navigation and UI resources for Thinkful.",
   "main": "src/index.es6",
   "scripts": {

--- a/src/OpenSessionOverview/OpenSessionOverview.jsx
+++ b/src/OpenSessionOverview/OpenSessionOverview.jsx
@@ -182,6 +182,8 @@ class OpenSessionOverview extends React.Component {
     } = this.props;
     const {detail_page_url, id} = session;
 
+    const userIsActive = !_.isEmpty(user) && user.account_status === 'active';
+
     return (
       <div className="qa-session-ctas">
         {linkToCalendar ?
@@ -192,7 +194,7 @@ class OpenSessionOverview extends React.Component {
             <Icon name="navigateright" className="button-right-icon"/>
           </a>
         : (
-          !user.isActive() ?
+          !userIsActive ?
             <a className="button" href={`${config.tfl_enroll.url}?rel=qa-session-details`}>
               RSVP
               <Icon name="navigateright" className="button-right-icon"/>

--- a/src/OpenSessionOverview/OpenSessionOverview.jsx
+++ b/src/OpenSessionOverview/OpenSessionOverview.jsx
@@ -192,7 +192,7 @@ class OpenSessionOverview extends React.Component {
             <Icon name="navigateright" className="button-right-icon"/>
           </a>
         : (
-          !user ?
+          !user.isActive() ?
             <a className="button" href={`${config.tfl_enroll.url}?rel=qa-session-details`}>
               RSVP
               <Icon name="navigateright" className="button-right-icon"/>

--- a/src/models/OpenSessionsModel.es6
+++ b/src/models/OpenSessionsModel.es6
@@ -62,7 +62,7 @@ OpenSession.prototype.isInactive = function() {
 }
 
 OpenSession.prototype.isWorkshop = function() {
-  return this.session_type === 'workshop'
+  return /(workshop|showcase)/.test(this.session_type);
 }
 
 OpenSession.prototype.userIsAttending = function(user) {


### PR DESCRIPTION
Goes along with https://github.com/Thinkful/cuckoo/pull/309 -- checks if a user is active in the `OpenSessionOverview` component before allowing them to RSVP.  Note this only applies to QA sessions (can't RSVP for a workshop from that overview screen)