### PR TITLE
TopicPicker Relocates to UI

### DIFF
--- a/client/DemoPage.jsx
+++ b/client/DemoPage.jsx
@@ -12,7 +12,8 @@ const {
   Icon,
   Loader,
   NotificationView,
-  OpenSessionOverview
+  OpenSessionOverview,
+  TopicPicker
 } = require('../src')
 
 require('./styles/demo.less')
@@ -142,6 +143,15 @@ class DemoPage extends React.Component {
               config: Demo.props.json({projects: {url: ''}})
             }}/>
 
+            <h3>TopicPicker</h3>
+            <Demo
+              target={TopicPicker}
+              props={{
+                addMatchEmphasis: Demo.props.bool(true),
+                minTopicLength: Demo.props.constant(3),
+                activeTopics: Demo.props.json(['HTML', 'CSS']),
+                availableTopics: Demo.props.json(
+                  ['HTML', 'CSS', 'React', 'Node'])}}/>
           <RouteHandler />
         </div>
         <Footer/>

--- a/client/DemoPage.jsx
+++ b/client/DemoPage.jsx
@@ -13,7 +13,7 @@ const {
   Loader,
   NotificationView,
   OpenSessionOverview,
-  TopicPicker
+  TopicPicker,
 } = require('../src')
 
 require('./styles/demo.less')
@@ -147,10 +147,15 @@ class DemoPage extends React.Component {
             <Demo
               target={TopicPicker}
               props={{
+                activeTopics: Demo.props.json(['foo', 'bar']),
                 addMatchEmphasis: Demo.props.bool(true),
-                activeTopics: Demo.props.json(['HTML', 'CSS']),
                 availableTopics: Demo.props.json(
-                  ['HTML', 'CSS', 'React', 'Node'])}}/>
+                  ['HTML', 'hockey', 'horses', 'hypervisor']),
+                className: Demo.props.constant('topic-picker-demo-page'),
+                handleUpdateTopics: Demo.props.callback.log,
+                maxSuggestions: Demo.props.choices([2, 3, 4]),
+                minTopicLength: 3,
+              }}/>
           <RouteHandler />
         </div>
         <Footer/>

--- a/client/DemoPage.jsx
+++ b/client/DemoPage.jsx
@@ -151,7 +151,6 @@ class DemoPage extends React.Component {
                 addMatchEmphasis: Demo.props.bool(true),
                 availableTopics: Demo.props.json(
                   ['HTML', 'hockey', 'horses', 'hypervisor']),
-                className: Demo.props.constant('topic-picker-demo-page'),
                 handleUpdateTopics: Demo.props.callback.log,
                 maxSuggestions: Demo.props.choices([2, 3, 4]),
                 minTopicLength: 3,

--- a/client/DemoPage.jsx
+++ b/client/DemoPage.jsx
@@ -148,7 +148,6 @@ class DemoPage extends React.Component {
               target={TopicPicker}
               props={{
                 addMatchEmphasis: Demo.props.bool(true),
-                minTopicLength: Demo.props.constant(3),
                 activeTopics: Demo.props.json(['HTML', 'CSS']),
                 availableTopics: Demo.props.json(
                   ['HTML', 'CSS', 'React', 'Node'])}}/>

--- a/client/styles/demo.less
+++ b/client/styles/demo.less
@@ -5,7 +5,3 @@
   padding-top: @gutter-px;
   padding-bottom: @column-px;
 }
-
-.topic-picker-demo-page {
-	height: 300px;
-}

--- a/client/styles/demo.less
+++ b/client/styles/demo.less
@@ -5,3 +5,7 @@
   padding-top: @gutter-px;
   padding-bottom: @column-px;
 }
+
+.topic-picker-demo-page {
+	height: 300px;
+}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "classnames": "^2.1.1",
     "css-loader": "^0.14.4",
     "debug": "^2.2.0",
+    "escape-string-regexp": "^1.0.3",
     "eslint": "^0.22.1",
     "eslint-loader": "^0.12.0",
     "extract-text-webpack-plugin": "^0.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkful-ui",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Shared navigation and UI resources for Thinkful.",
   "main": "src/index.es6",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkful-ui",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Shared navigation and UI resources for Thinkful.",
   "main": "src/index.es6",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "less": "^2.5.1",
     "less-loader": "^2.2.0",
     "lodash": "^3.9.3",
+    "marked": "^0.3.5",
     "moment": "^2.10.3",
     "moment-timezone": "^0.4.0",
     "node-libs-browser": "^0.5.2",

--- a/src/OpenSessionOverview/OpenSessionOverview.jsx
+++ b/src/OpenSessionOverview/OpenSessionOverview.jsx
@@ -135,7 +135,11 @@ class OpenSessionOverview extends React.Component {
             {!!tags.length &&
               <div className="session-tags">
                 {tags.map(
-                  (t, idx) => <Tag key={idx} displayName={t} config={config}/>)}
+                  (t, idx) => <Tag
+                                key={idx}
+                                displayName={t}
+                                url={`${config.projects.url}/search?q=${t}`}/>)
+              }
               </div>
             }
             {rsvp_contact_ids && !!rsvp_contact_ids.length &&

--- a/src/Tag/Tag.jsx
+++ b/src/Tag/Tag.jsx
@@ -2,12 +2,21 @@ const cx = require('classnames');
 const React = require('react');
 
 class Tag extends React.Component {
+
+  static displayName = 'Tag'
+
+  static propTypes = {
+    className: React.PropTypes.string,
+    displayName: React.PropTypes.string,
+    url: React.PropTypes.string
+  }
+
   render() {
-    const {children, className, config, displayName} = this.props;
+    const {children, className, displayName, url} = this.props;
     return (
       <a
           className={cx("tui-tag", className)}
-          href={`${config.projects.url}/search?q=${displayName}`}>
+          href={url}>
         {displayName}
         {children}
       </a>

--- a/src/TopicPicker/TopicPicker.jsx
+++ b/src/TopicPicker/TopicPicker.jsx
@@ -39,6 +39,8 @@ class TopicPicker extends React.Component {
     };
   }
 
+  static displayName = 'TopicPicker'
+
   static propTypes = {
     activeTopics: React.PropTypes.array,
     availableTopics: React.PropTypes.array,

--- a/src/TopicPicker/TopicPicker.jsx
+++ b/src/TopicPicker/TopicPicker.jsx
@@ -209,6 +209,12 @@ class TopicPicker extends React.Component {
     }
   }
 
+  _toggleFocus = () => {
+    this.setState({
+      isFocused: !this.state.isFocused
+    })
+  }
+
   /*
    * Getter for topics
    */
@@ -217,9 +223,13 @@ class TopicPicker extends React.Component {
   }
 
   render() {
-    const {pattern, topics, selectedSuggestionIndex} = this.state;
+    const {pattern, topics, selectedSuggestionIndex, isFocused} = this.state;
     return (
-      <div className={cx('topic-picker', this.props.className)}>
+      <div
+        className={cx(
+          'topic-picker',
+          this.props.className,
+          isFocused && 'topic-picker-focus')}>
 
         {/* The existing topics */}
         {topics.map((topic, index) => {
@@ -242,6 +252,8 @@ class TopicPicker extends React.Component {
             className="topic-form"
             onSubmit={this._handleTopicSubmit}>
           <input
+              onFocus={this._toggleFocus}
+              onBlur={this._toggleFocus}
               className="topic-form-input"
               ref="topicInput"
               type="text"

--- a/src/TopicPicker/TopicPicker.jsx
+++ b/src/TopicPicker/TopicPicker.jsx
@@ -2,18 +2,16 @@ const cx = require('classnames');
 const escapeStringRegexp = require('escape-string-regexp');
 const marked = require('marked');
 const React = require('react');
-const ReactDOM = require('react-dom');
 
 const {Icon} = require('../Icon');
 const {Tag} = require('../Tag');
-
 
 const DOWN_ARROW_KEY_CODE = 40;
 const UP_ARROW_KEY_CODE = 38;
 const COMMA_KEY_CODE = 188;
 const RETURN_KEY_CODE = 13;
 
-const DEFAULT_MIN_TOPIC_LENGTH = 0;
+const DEFAULT_MIN_TOPIC_LENGTH = 1;
 
 /*
  * TopicPicker component
@@ -64,14 +62,11 @@ class TopicPicker extends React.Component {
   componentDidMount() {
     const {activeTopics} = this.props;
     this.setState({topics: activeTopics});
-
-    ReactDOM.findDOMNode(this.refs.topicForm).
-      addEventListener('keydown', e => this._handleKeyDown(e));
+    this.refs.topicForm.addEventListener('keydown', this._handleKeyDown);
   }
 
   componentWillUnmount() {
-    ReactDOM.findDOMNode(this.refs.topicForm).
-      removeEventListener('keydown', e => this._handleKeyDown(e));
+   this.refs.topicForm.removeEventListener('keydown', this._handleKeyDown);
   }
 
   componentWillReceiveProps(newProps) {
@@ -209,7 +204,7 @@ class TopicPicker extends React.Component {
       topic = this.refs.topicInput.value;
     }
 
-    if (topic.length > this.props.minTopicLength) {
+    if (topic.length >= this.props.minTopicLength) {
       this._handleAddTopic(topic);
     }
   }

--- a/src/TopicPicker/TopicPicker.jsx
+++ b/src/TopicPicker/TopicPicker.jsx
@@ -1,0 +1,268 @@
+const cx = require('classnames');
+const marked = require('marked');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const {Icon} = require('../Icon');
+
+
+const DOWN_ARROW_KEY_CODE = 40;
+const UP_ARROW_KEY_CODE = 38;
+const COMMA_KEY_CODE = 188;
+const RETURN_KEY_CODE = 13;
+
+const MIN_TOPIC_LENGTH = 3;
+
+/*
+ * TopicPicker component
+ *
+ * Interface:
+ *   use the `getTopics` function on the component to get the internal
+ *   list of picked topics
+ *
+ * @property {Array} availableTopics the Array of topic to suggest
+ * @property {Array} activeTopics the Array of topics to prefill
+ * @property {Boolean} addMatchEmphasis Add `em` tags around tag matches
+ * @property {Func} handleUpdateTopics callback func on topic update
+ * @property {Number} maxSuggestions The max number of suggestions to show
+ * @property {Number} minTopicLength The min length a topic string must be
+ */
+class TopicPicker extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      pattern: '',
+      topics: [],
+      selectedSuggestionIndex: -1
+    };
+  }
+
+  static propTypes = {
+    activeTopics: React.PropTypes.array,
+    availableTopics: React.PropTypes.array,
+    addMatchEmphasis: React.PropTypes.bool,
+    handleUpdateTopics: React.PropTypes.func,
+    maxSuggestions: React.PropTypes.number,
+  }
+
+  static defaultProps = {
+    availableTopics: [],
+    activeTopics: [],
+    // if parent doesn't pass in callback, to avoid conditionals inline
+    handleUpdateTopics: () => null,
+  }
+
+  componentDidMount() {
+    const {activeTopics} = this.props;
+    this.setState({topics: activeTopics});
+
+    ReactDOM.findDOMNode(this.refs.topicForm).
+      addEventListener('keydown', e => this._handleKeyDown(e));
+  }
+
+  componentWillUnmount() {
+    ReactDOM.findDOMNode(this.refs.topicForm).
+      removeEventListener('keydown', e => this._handleKeyDown(e));
+  }
+
+  componentWillReceiveProps(newProps) {
+    const {activeTopics} = newProps;
+    this.setState({topics: activeTopics});
+  }
+
+  _handleKeyDown = (event) => {
+    const {selectedSuggestionIndex} = this.state;
+    const suggestions = this._filterTopicList();
+
+    if (event.which === DOWN_ARROW_KEY_CODE) {
+      this.setState({
+        selectedSuggestionIndex: Math.min(
+          selectedSuggestionIndex + 1, suggestions.length - 1)});
+    }
+    else if (event.which === UP_ARROW_KEY_CODE) {
+      this.setState({
+        selectedSuggestionIndex: Math.max(
+          selectedSuggestionIndex - 1, 0)});
+    }
+    else if (
+        (event.which == COMMA_KEY_CODE) ||
+        (event.which == RETURN_KEY_CODE)) {
+      this._handleTopicSubmit(event);
+    }
+  }
+
+  /*
+   * Move the selected suggestion by `numMoves`
+   *
+   * Usable in keydown handler for moving selected topic in suggestion list
+   */
+  _handleMoveSelected = (numMoves) => {
+    const {availableTopics} = this.props;
+    const {selectedSuggestionIndex} = this.state;
+    const newSelectedIndex = selectedSuggestionIndex + numMoves
+
+    if (newSelectedIndex >= -1 && newSelectedIndex < (availableTopics || []).length) {
+      this.setState({selectedSuggestionIndex: newSelectedIndex});
+    }
+  }
+
+  /*
+   * Handler for a form change
+   */
+  _handlePatternChange = (event) => {
+    this.setState({pattern: event.target.value})
+  }
+
+  /*
+   * Return the `availableTopics`, filtered for a matching pattern
+   *
+   * This makes the topics markdown to add emphasis if the property
+   * `addMatchEmphasis` is truthy.
+   */
+  _filterTopicList = (additionalTopics) => {
+    const {pattern, topics} = this.state;
+
+    const {availableTopics, addMatchEmphasis, de} = this.props;
+    const maxSuggestions = this.props.maxSuggestions || 10;
+
+    // find and mark the pattern matches in a case-insensitive way
+    return (availableTopics).
+      filter(topic => { // filter for matching available topics
+        return topic.toLowerCase().match(pattern.toLowerCase()) &&
+               topics.indexOf(topic) < 0
+      }).
+      slice(0, maxSuggestions). // limit the number of results
+      map(topic => { // add the asterisks for emphasis around matching area
+        if (addMatchEmphasis) {
+          const firstIndex = topic.toLowerCase().
+            indexOf(topic.toLowerCase().match(pattern.toLowerCase())[0])
+          const lastIndex = firstIndex + pattern.length + 1;
+
+          let topicArray = topic.split('');
+          topicArray.splice(firstIndex, 0, '*')
+          topicArray.splice(lastIndex, 0, '*')
+          return topicArray.join('');
+        }
+        else {
+          return topic
+        }
+      })
+  }
+
+  /*
+   * Add a topic to the internal list of topics
+   */
+  _handleAddTopic = (topic) => {
+    const {topics} = this.state;
+    const {handleUpdateTopics} = this.props;
+
+    if (topics.map(t => t.toLowerCase()).indexOf(topic.toLowerCase()) < 0) {
+      // We trim the whitespace off the tag before adding it
+      let newTopics = topics.concat(topic.trim());
+      this.setState({topics: newTopics});
+      handleUpdateTopics(newTopics);
+    }
+
+    this.setState({pattern: '', selectedSuggestionIndex: -1});
+  }
+
+  /*
+   * Remove a topic from the internal list of topics, if it's present
+   *
+   * Matching is case-sensitive
+   */
+  _handleRemoveTopic = (topic) => {
+    const {topics} = this.state;
+    const {handleUpdateTopics} = this.props;
+
+    let newTopics = topics.filter(t => t !== topic);
+
+    this.setState({topics: newTopics});
+    handleUpdateTopics(newTopics);
+  }
+
+  /*
+   * Handle submission of a new topic
+   */
+  _handleTopicSubmit = (event) => {
+    if (event && event.preventDefault) {
+      event.preventDefault();
+    }
+    const {selectedSuggestionIndex} = this.state;
+    let topic;
+
+    if (selectedSuggestionIndex > -1) {
+      topic = this._filterTopicList()[selectedSuggestionIndex];
+    }
+    else {
+      topic = this.refs.topicInput.value;
+    }
+
+    if (topic.length > this.props.minTopicLength || MIN_TOPIC_LENGTH) {
+      this._handleAddTopic(topic);
+    }
+  }
+
+  /*
+   * Getter for topics
+   */
+  getTopics() {
+    return this.state.topics;
+  }
+
+  render() {
+    const {pattern, topics, selectedSuggestionIndex} = this.state;
+    return (
+      <div className="topic-picker">
+
+        {/* The existing topics */}
+        {topics.map((topic, index) => {
+          return (
+            <div className="topic" key={index}>
+              <div className="topic-name">{topic}</div>
+              <div
+                  className="topic-delete-button"
+                  onClick={(event) => this._handleRemoveTopic(topic)}>
+                <Icon name="close"/>
+              </div>
+            </div>
+          );
+        })}
+
+        <div
+            ref="topicForm"
+            className="topic-form"
+            onSubmit={this._handleTopicSubmit}>
+          <input
+              ref="topicInput"
+              type="text"
+              value={pattern}
+              placeholder="Add a tag (hit 'return' after each one)"
+              onChange={this._handlePatternChange}/>
+
+          {/* The list of topic suggestions */}
+          {pattern && (
+            <ul className="topic-suggestion-list">
+              {this._filterTopicList().map((topic, index) => {
+                return (
+                  <li
+                    key={index}
+                    className={cx(
+                      'topic-list-item',
+                      {selected: index === selectedSuggestionIndex})
+                    }
+                    onClick={(event) => this._handleAddTopic(
+                      topic.replace(/\*/g, ''))
+                    }
+                    dangerouslySetInnerHTML={{__html: marked(topic)}}/>
+                );
+              })}
+            </ul>
+            )
+          }
+        </div>
+      </div>
+    );
+  }
+}
+
+module.exports = {TopicPicker}

--- a/src/TopicPicker/TopicPicker.jsx
+++ b/src/TopicPicker/TopicPicker.jsx
@@ -1,10 +1,11 @@
 const cx = require('classnames');
 const escapeStringRegexp = require('escape-string-regexp');
 const marked = require('marked');
-
 const React = require('react');
 const ReactDOM = require('react-dom');
+
 const {Icon} = require('../Icon');
+const {Tag} = require('../Tag');
 
 
 const DOWN_ARROW_KEY_CODE = 40;
@@ -12,7 +13,7 @@ const UP_ARROW_KEY_CODE = 38;
 const COMMA_KEY_CODE = 188;
 const RETURN_KEY_CODE = 13;
 
-const MIN_TOPIC_LENGTH = 3;
+const DEFAULT_MIN_TOPIC_LENGTH = 0;
 
 /*
  * TopicPicker component
@@ -45,14 +46,17 @@ class TopicPicker extends React.Component {
     activeTopics: React.PropTypes.array,
     availableTopics: React.PropTypes.array,
     addMatchEmphasis: React.PropTypes.bool,
+    className: React.PropTypes.string,
     handleUpdateTopics: React.PropTypes.func,
     maxSuggestions: React.PropTypes.number,
+    minTopicLength: React.PropTypes.number,
   }
 
   static defaultProps = {
     availableTopics: [],
     activeTopics: [],
     maxSuggestions: 10,
+    minTopicLength: DEFAULT_MIN_TOPIC_LENGTH,
     // if parent doesn't pass in callback, to avoid conditionals inline
     handleUpdateTopics: () => null,
   }
@@ -205,7 +209,7 @@ class TopicPicker extends React.Component {
       topic = this.refs.topicInput.value;
     }
 
-    if (topic.length > this.props.minTopicLength || MIN_TOPIC_LENGTH) {
+    if (topic.length > this.props.minTopicLength) {
       this._handleAddTopic(topic);
     }
   }
@@ -225,14 +229,16 @@ class TopicPicker extends React.Component {
         {/* The existing topics */}
         {topics.map((topic, index) => {
           return (
-            <div className="topic" key={index}>
-              <div className="topic-name">{topic}</div>
+            <Tag
+              key={index}
+              className='topic'
+              displayName={topic}>
               <div
                   className="topic-delete-button"
                   onClick={(event) => this._handleRemoveTopic(topic)}>
                 <Icon name="close"/>
               </div>
-            </div>
+            </Tag>
           );
         })}
 

--- a/src/TopicPicker/index.es6
+++ b/src/TopicPicker/index.es6
@@ -1,0 +1,5 @@
+const {TopicPicker} = require('./TopicPicker');
+
+require('./topic-picker.less');
+
+module.exports = {TopicPicker}

--- a/src/TopicPicker/index.es6
+++ b/src/TopicPicker/index.es6
@@ -1,5 +1,2 @@
-const {TopicPicker} = require('./TopicPicker');
-
 require('./topic-picker.less');
-
-module.exports = {TopicPicker}
+export default require('./TopicPicker')

--- a/src/TopicPicker/topic-picker.less
+++ b/src/TopicPicker/topic-picker.less
@@ -8,15 +8,15 @@
   border: 1px mix(@gray25, @gray50, 70%) solid;
   box-shadow: inset 0 3px 7px @gray15;
   border-radius: 3px;
-  &:focus {
-    border-color: @blue;
-  }
 
   @media @nonmobile {
     display: flex;
     align-items: center;
-
   }
+}
+
+.topic-picker-focus {
+  border-color: @blue;
 }
 
 .topic {

--- a/src/TopicPicker/topic-picker.less
+++ b/src/TopicPicker/topic-picker.less
@@ -1,0 +1,126 @@
+@import "~tfstyleguide/vars";
+
+.topic-picker {
+  width: 100%;
+  padding-left: 1em;
+  align-items: flex-start;
+  // flex-wrap: wrap;
+  overflow-x: scroll;
+
+  @media @nonmobile {
+    border: 1px mix(@gray25, @gray50, 70%) solid;
+    box-shadow: inset 0 3px 7px @gray15;
+    border-radius: 3px;
+    display: flex;
+    align-items: center;
+
+    &:focus {
+      border-color: @blue;
+    }
+  }
+}
+
+.topic {
+  .body-text;
+  line-height: 23px;
+  color: @blue;
+  position: relative;
+  flex-shrink: 0;
+  flex-grow: 0;
+  display: inline-block;
+  border-radius: 3px;
+  border: 1px @blue solid;
+  padding-left: 8px;
+  padding-right: 8px;
+  margin-right: 5px;
+  margin-bottom: 5px;
+
+  &:last-child {
+    margin-right: 0;
+  }
+
+  @media @nonmobile {
+    display: inherit;
+    margin-bottom: 0;
+  }
+
+  .topic-delete-button {
+    position: relative;
+    display: inline-block;
+    vertical-align: bottom;
+    padding-left: 4px;
+    padding-right: 5px;
+    margin-right: -5px;
+    font-size: 25px;
+    cursor: pointer;
+
+    &:hover {
+      color: @gray50;
+    }
+  }
+}
+
+.topic-form {
+  position: relative;
+  width: 100%;
+
+  input {
+    max-width: none;
+    min-width: 0;
+    flex-shrink: 1;
+    width: 100%;
+    margin-bottom: 0;
+    border: none;
+    background-color: transparent;
+    box-shadow: none;
+
+    &:focus {
+      outline: none;
+      border: none;
+      box-shadow: none;
+    }
+  }
+}
+
+.topic-suggestion-list {
+  position: absolute;
+  top: 45px;
+  left: 1em;
+  padding: 0;
+  margin: 0;
+  // background-color: @gray25;
+  z-index: 1;
+}
+
+.topic-list-item {
+  max-width: 200px;
+  list-style: none;
+  padding: 2px 15px 5px 15px;
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  cursor: pointer;
+
+  p {
+    .monospace;
+  }
+
+  em {
+    font-style: normal;
+    font-weight: 600;
+    border-bottom: 2px @black solid;
+  }
+
+  &:hover {
+    background-color: @blue25;
+  }
+
+  &.selected {
+    background-color: @blue50;
+  }
+
+  p, a, {
+    margin-bottom: 0;
+  }
+}
+

--- a/src/TopicPicker/topic-picker.less
+++ b/src/TopicPicker/topic-picker.less
@@ -4,7 +4,6 @@
   width: 100%;
   padding-left: 1em;
   align-items: flex-start;
-  overflow-x: scroll;
   border: 1px mix(@gray25, @gray50, 70%) solid;
   box-shadow: inset 0 3px 7px @gray15;
   border-radius: 3px;
@@ -82,6 +81,7 @@
 }
 
 .topic-suggestion-list {
+  overflow: visible;
   position: absolute;
   top: 45px;
   left: 1em;

--- a/src/TopicPicker/topic-picker.less
+++ b/src/TopicPicker/topic-picker.less
@@ -4,7 +4,6 @@
   width: 100%;
   padding-left: 1em;
   align-items: flex-start;
-  // flex-wrap: wrap;
   overflow-x: scroll;
 
   @media @nonmobile {
@@ -64,7 +63,7 @@
   position: relative;
   width: 100%;
 
-  input {
+  input.topic-form-input {
     max-width: none;
     min-width: 0;
     flex-shrink: 1;

--- a/src/TopicPicker/topic-picker.less
+++ b/src/TopicPicker/topic-picker.less
@@ -5,17 +5,17 @@
   padding-left: 1em;
   align-items: flex-start;
   overflow-x: scroll;
+  border: 1px mix(@gray25, @gray50, 70%) solid;
+  box-shadow: inset 0 3px 7px @gray15;
+  border-radius: 3px;
+  &:focus {
+    border-color: @blue;
+  }
 
   @media @nonmobile {
-    border: 1px mix(@gray25, @gray50, 70%) solid;
-    box-shadow: inset 0 3px 7px @gray15;
-    border-radius: 3px;
     display: flex;
     align-items: center;
 
-    &:focus {
-      border-color: @blue;
-    }
   }
 }
 

--- a/src/TopicPicker/topic-picker.less
+++ b/src/TopicPicker/topic-picker.less
@@ -87,7 +87,7 @@
   left: 1em;
   padding: 0;
   margin: 0;
-  // background-color: @gray25;
+  background-color: @gray25;
   z-index: 1;
 }
 
@@ -95,7 +95,6 @@
   max-width: 200px;
   list-style: none;
   padding: 2px 15px 5px 15px;
-  margin-top: 0;
   margin-bottom: 0;
   margin-left: 0;
   cursor: pointer;

--- a/src/index.es6
+++ b/src/index.es6
@@ -14,6 +14,7 @@ const {pathWithSlug, pathWithoutSlug} = require('./ProxyPathUtils');
 const {SearchBar} = require('./SearchBar');
 const {SidebarLayout, SidebarMenu, SidebarMenuItem} = require('./Sidebar');
 const {Tag} = require('./Tag');
+const {TopicPicker} = require('./TopicPicker');
 const {TrackedLink, AnalyticsAPI} = require('./analytics');
 const {models} = require('./models');
 
@@ -38,6 +39,7 @@ module.exports = {
   SidebarMenu,
   SidebarMenuItem,
   Tag,
+  TopicPicker,
   TrackedLink,
   AnalyticsAPI,
   models


### PR DESCRIPTION
Note:

* This required small changes to `Tag` component
* Fixes a bug in `_filterTopicList` whereby inputting a topic like `C++` when `availableTopics` was passed in caused an error.
* Makes `minTopicLength` configurable, but defaults to 0.
* Has new requirements so running locally will need to ./script/install

Also, shortly after this is released, both Raven and Cuckoo will be updated to comply with updated `Tag` props, and to use `TopicPicker` from UI.