### PR TITLE
Check for undefined "to" and "from" args

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkful-ui",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Shared navigation and UI resources for Thinkful.",
   "main": "src/index.es6",
   "scripts": {

--- a/src/analytics/actions.es6
+++ b/src/analytics/actions.es6
@@ -161,8 +161,8 @@ function alias(to, from, options, fn) {
     if (is.object(from)) options = from, from = null;
 
     // Aliasing Thinkful emails is dangerous, as we impersonate
-    if (to.indexOf('@thinkful.com') == -1 &&
-            from.indexOf('@thinkful.com') == -1) {
+    if (to && to.indexOf('@thinkful.com') == -1 &&
+            (! from || from.indexOf('@thinkful.com') == -1)) {
 
         global.analytics &&
             global.analytics.alias(to, from, options, fn);


### PR DESCRIPTION
Fixes the error thrown for some secret signup enrollments when no "from" address is passed to AnalyticsAPI.alias. 

This addresses https://github.com/Thinkful/Thinkful/issues/154 