### PR TITLE
get rid of use of refs and use onKeyDown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkful-ui",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Shared navigation and UI resources for Thinkful.",
   "main": "src/index.es6",
   "scripts": {

--- a/src/TopicPicker/TopicPicker.jsx
+++ b/src/TopicPicker/TopicPicker.jsx
@@ -56,6 +56,7 @@ class TopicPicker extends React.Component {
     activeTopics: [],
     maxSuggestions: 10,
     minTopicLength: DEFAULT_MIN_TOPIC_LENGTH,
+    placeholderText: "Add a tag (hit 'return' after each one)",
     // if parent doesn't pass in callback, to avoid conditionals inline
     handleUpdateTopics: () => null,
   }
@@ -220,6 +221,7 @@ class TopicPicker extends React.Component {
 
   render() {
     const {pattern, topics, selectedSuggestionIndex, isFocused} = this.state;
+    const {className, placeholderText} = this.props;
     return (
       <div
         className={cx(
@@ -253,7 +255,7 @@ class TopicPicker extends React.Component {
               className="topic-form-input"
               type="text"
               value={pattern}
-              placeholder="Add a tag (hit 'return' after each one)"
+              placeholder={placeholderText}
               onChange={this._handlePatternChange}/>
 
           {/* The list of topic suggestions */}

--- a/src/TopicPicker/TopicPicker.jsx
+++ b/src/TopicPicker/TopicPicker.jsx
@@ -34,7 +34,6 @@ class TopicPicker extends React.Component {
     this.state = {
       pattern: '',
       topics: [],
-      topicFormInputValue: null,
       selectedSuggestionIndex: -1
     };
   }
@@ -226,7 +225,7 @@ class TopicPicker extends React.Component {
       <div
         className={cx(
           'topic-picker',
-          this.props.className,
+          className,
           isFocused && 'topic-picker-focus')}>
 
         {/* The existing topics */}

--- a/src/TopicPicker/TopicPicker.jsx
+++ b/src/TopicPicker/TopicPicker.jsx
@@ -34,6 +34,7 @@ class TopicPicker extends React.Component {
     this.state = {
       pattern: '',
       topics: [],
+      topicFormInputValue: null,
       selectedSuggestionIndex: -1
     };
   }
@@ -62,11 +63,6 @@ class TopicPicker extends React.Component {
   componentDidMount() {
     const {activeTopics} = this.props;
     this.setState({topics: activeTopics});
-    this.refs.topicForm.addEventListener('keydown', this._handleKeyDown);
-  }
-
-  componentWillUnmount() {
-   this.refs.topicForm.removeEventListener('keydown', this._handleKeyDown);
   }
 
   componentWillReceiveProps(newProps) {
@@ -201,7 +197,7 @@ class TopicPicker extends React.Component {
       topic = this._filterTopicList()[selectedSuggestionIndex];
     }
     else {
-      topic = this.refs.topicInput.value;
+      topic = this.state.pattern;
     }
 
     if (topic.length >= this.props.minTopicLength) {
@@ -248,14 +244,13 @@ class TopicPicker extends React.Component {
         })}
 
         <div
-            ref="topicForm"
             className="topic-form"
+            onKeyDown={this._handleKeyDown}
             onSubmit={this._handleTopicSubmit}>
           <input
               onFocus={this._toggleFocus}
               onBlur={this._toggleFocus}
               className="topic-form-input"
-              ref="topicInput"
               type="text"
               value={pattern}
               placeholder="Add a tag (hit 'return' after each one)"


### PR DESCRIPTION
topic picker was failing in some apps with error
discussed here: https://gist.github.com/jimfb/4faa6cbfb1ef476bd105

after numerous dead ends, turned out that the refs inside
TopicPicker were causing this issue. Easily addressed by getting
rid of refs.