### PR TITLE
Alias react

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkful-ui",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "Shared navigation and UI resources for Thinkful.",
   "main": "src/index.es6",
   "scripts": {

--- a/webpack.defaults.js
+++ b/webpack.defaults.js
@@ -71,7 +71,10 @@ module.exports = function (options) {
     plugins: [],
     resolve: {
       extensions: ['', '.js', '.jsx', '.es', '.es6'],
-      alias: {app: path.join(options.__dirname, 'client')}
+      alias: {
+        app: path.join(options.__dirname, 'client'),
+        react: path.join(__dirname, 'node_modules', 'react')
+      }
     },
     resolveLoader: {
       root: path.join(__dirname, 'node_modules')},


### PR DESCRIPTION
This appears to solve the dreaded invariant violation error we've been getting when using components with `.refs` from thinkful-ui (discussed [here](https://gist.github.com/jimfb/4faa6cbfb1ef476bd105)).