### PR TITLE
add social share wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkful-ui",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "description": "Shared navigation and UI resources for Thinkful.",
   "main": "src/index.es6",
   "scripts": {

--- a/src/Sidebar/Layout.jsx
+++ b/src/Sidebar/Layout.jsx
@@ -9,7 +9,7 @@ require('./layout.less');
  */
 class SidebarLayout extends React.Component {
   static propTypes = {
-    sidebarMenu: React.PropTypes.component
+    sidebarMenu: React.PropTypes.element
   }
 
   render() {

--- a/src/SocialShare/SocialShare.jsx
+++ b/src/SocialShare/SocialShare.jsx
@@ -1,0 +1,78 @@
+const cx = require('classnames');
+const React = require('react');
+
+/**
+  This component can act as a wrapper around anything that should behave as
+  a social share link.  Currently supports facebook, twitter and linked in.
+ */
+class SocialShare extends React.Component {
+  static propTypes = {
+    type: React.PropTypes.oneOf(['facebook', 'twitter', 'linkedin']),
+    handleTrackClick: React.PropTypes.func
+  }
+
+  _openSocialShareWindow = (width, height, location) => {
+    window.open(location, '',
+      `menubar=no,toolbar=no,resizable=yes,scrollbars=yes,` +
+      `height=${height},width=${width},left=500`);
+    return false;
+  }
+
+  _coerceTwitterConfig = (data) => {
+    return {
+      url: `http://twitter.com/home/?status=${this.props.content}`,
+      width: 600,
+      height: 250
+    }
+  }
+
+  _coerceFacebookConfig = (data) => {
+    return {
+      url: `https://www.facebook.com/sharer/sharer.php?u=${this.props.url}`,
+      width: 600,
+      height: 300
+    }
+  }
+
+  _coerceLinkedInConfig = (data) => {
+    return {
+      url: `http://www.linkedin.com/shareArticle?mini=true&url=${this.props.url}`,
+      width: 600,
+      height: 300
+    }
+  }
+
+  _coerceFromType = (type, data) => {
+    switch (type) {
+    case 'twitter':
+      return this._coerceTwitterConfig(data);
+      break;
+    case 'facebook':
+      return this._coerceFacebookConfig(data);
+      break;
+    case 'linkedin':
+      return this._coerceLinkedInConfig(data);
+      break;
+    default: return {}
+    }
+  }
+
+  _handleSocialShareClick = () => {
+    const {handleTrackClick, type} = this.props;
+
+    handleTrackClick && handleTrackClick();
+
+    const values = this._coerceFromType(type);
+    this._openSocialShareWindow(values.width, values.height, values.url);
+  }
+
+  render() {
+    return <div
+        className={cx("social-link-wrapper", this.props.className)}
+        onClick={this._handleSocialShareClick}>
+      {this.props.children}
+    </div>
+  }
+}
+
+module.exports = {SocialShare}

--- a/src/SocialShare/SocialShare.jsx
+++ b/src/SocialShare/SocialShare.jsx
@@ -44,7 +44,7 @@ class SocialShare extends React.Component {
   _handleSocialShareClick = () => {
     const {handleTrackClick, type} = this.props;
 
-    handleTrackClick && handleTrackClick();
+    handleTrackClick && handleTrackClick(type);
 
     const values = this._coerceFromType(type);
     this._openSocialShareWindow(values.width, values.height, values.url);

--- a/src/SocialShare/SocialShare.jsx
+++ b/src/SocialShare/SocialShare.jsx
@@ -18,43 +18,27 @@ class SocialShare extends React.Component {
     return false;
   }
 
-  _coerceTwitterConfig = (data) => {
-    return {
-      url: `http://twitter.com/home/?status=${this.props.content}`,
-      width: 600,
-      height: 250
+  _coerceFromType = (type) => {
+    const {content, url} = this.props;
+    const urlBuilders = {
+      twitter: {
+        url: `https://twitter.com/home/?status=${content}`,
+        width: 600,
+        height: 250
+      },
+      facebook: {
+        url: `https://www.facebook.com/sharer/sharer.php?u=${url}`,
+        width: 600,
+        height: 300
+      },
+      linkedin: {
+        url: `https://www.linkedin.com/shareArticle?mini=true&url=${url}`,
+        width: 600,
+        height: 300
+      }
     }
-  }
 
-  _coerceFacebookConfig = (data) => {
-    return {
-      url: `https://www.facebook.com/sharer/sharer.php?u=${this.props.url}`,
-      width: 600,
-      height: 300
-    }
-  }
-
-  _coerceLinkedInConfig = (data) => {
-    return {
-      url: `http://www.linkedin.com/shareArticle?mini=true&url=${this.props.url}`,
-      width: 600,
-      height: 300
-    }
-  }
-
-  _coerceFromType = (type, data) => {
-    switch (type) {
-    case 'twitter':
-      return this._coerceTwitterConfig(data);
-      break;
-    case 'facebook':
-      return this._coerceFacebookConfig(data);
-      break;
-    case 'linkedin':
-      return this._coerceLinkedInConfig(data);
-      break;
-    default: return {}
-    }
+    return urlBuilders[type] || {};
   }
 
   _handleSocialShareClick = () => {

--- a/src/SocialShare/index.es6
+++ b/src/SocialShare/index.es6
@@ -1,1 +1,3 @@
+require('./social-share.less');
+
 export default require('./SocialShare');

--- a/src/SocialShare/index.es6
+++ b/src/SocialShare/index.es6
@@ -1,0 +1,1 @@
+export default require('./SocialShare');

--- a/src/SocialShare/social-share.less
+++ b/src/SocialShare/social-share.less
@@ -1,0 +1,10 @@
+@import "~tfstyleguide/vars";
+
+.social-link-wrapper {
+  display: inline-block;
+  cursor: pointer;
+  color: @blue;
+  &:hover {
+    color: @blue75;
+  }
+}

--- a/src/index.es6
+++ b/src/index.es6
@@ -14,6 +14,7 @@ const {OpenSessionOverview} = require('./OpenSessionOverview');
 const {pathWithSlug, pathWithoutSlug} = require('./ProxyPathUtils');
 const {SearchBar} = require('./SearchBar');
 const {SidebarLayout, SidebarMenu, SidebarMenuItem} = require('./Sidebar');
+const {SocialShare} = require('./SocialShare');
 const {Tag} = require('./Tag');
 const {TopicPicker} = require('./TopicPicker');
 const {TrackedLink, AnalyticsAPI} = require('./analytics');
@@ -40,6 +41,7 @@ module.exports = {
   SidebarLayout,
   SidebarMenu,
   SidebarMenuItem,
+  SocialShare,
   Tag,
   TopicPicker,
   TrackedLink,


### PR DESCRIPTION
Adds a component that you can use to automagically create a social share button for twitter, linkedin or facebook.  It's very un-opinionated on what the element should look like because we may want buttons vs icons at various spots throughout the site.  Component takes a `url` (facebook and linkedin) or `content` (twitter) to share 

usage:
```
<SocialShare type="twitter" content="A tweet">
  <Icon name="twitter"/>
</SocialShare>
```