### PR TITLE
Small fix for edge case in identifying with traits as first parameter and no ID.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkful-ui",
-  "version": "2.0.40",
+  "version": "2.0.41",
   "description": "Shared navigation and UI resources for Thinkful.",
   "main": "src/index.es6",
   "scripts": {

--- a/src/analytics/actions.es6
+++ b/src/analytics/actions.es6
@@ -170,7 +170,7 @@ function identify(id, traits, options, fn) {
     // Argument reshuffling, from original library.
     if (is.function(options)) fn = options, options = null;
     if (is.function(traits)) fn = traits, options = null, traits = null;
-    if (is.object(id)) options = traits, traits = id, id = window.analytics._user.id();
+    if (is.object(id)) options = traits, traits = id, id = null;
 
     let email = tryEmail();
 

--- a/src/analytics/actions.es6
+++ b/src/analytics/actions.es6
@@ -170,7 +170,7 @@ function identify(id, traits, options, fn) {
     // Argument reshuffling, from original library.
     if (is.function(options)) fn = options, options = null;
     if (is.function(traits)) fn = traits, options = null, traits = null;
-    if (is.object(id)) options = traits, traits = id, id = user.id();
+    if (is.object(id)) options = traits, traits = id, id = window.analytics._user.id();
 
     let email = tryEmail();
 


### PR DESCRIPTION
I don't believe we have any code in the wild that actually hits this, but I noticed it and it should be fixed anyways.