### PR TITLE
Changes to allow for getting most up-to-date __env.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkful-ui",
-  "version": "2.0.41",
+  "version": "2.0.44",
   "description": "Shared navigation and UI resources for Thinkful.",
   "main": "src/index.es6",
   "scripts": {

--- a/src/analytics/actions.es6
+++ b/src/analytics/actions.es6
@@ -16,29 +16,29 @@ const cookies = zipObject(map(document.cookie.split('; '), function(cookie) {
 }));
 
 function app() {
-  return get(global, '__env.config.app.name', '').toLowerCase();
+    return get(global, '__env.config.app.name', '').toLowerCase();
 }
 
 function appInfo() {
-  return {
-      app: app(),
-      appDisplayName: get(global, '__env.config.app.displayName', '').toLowerCase(),
-      uiAnalytics: true
-  }
+    return {
+        app: app(),
+        appDisplayName: get(global, '__env.config.app.displayName', '').toLowerCase(),
+        uiAnalytics: true
+    }
 }
 
 function isLoggedIn() {
-  return has(global, '__env.user') && is.object(global.__env.user);
+    return has(global, '__env.user') && is.object(global.__env.user);
 }
 
 function isImpersonating() {
-  const impersonating = has(global, '__env.user.real_admin_tf_login');
+    const impersonating = has(global, '__env.user.real_admin_tf_login');
 
-  if (impersonating) {
-    log('No analyitcs for impersonating users.');
-  }
+    if (impersonating) {
+        log('No analyitcs for impersonating users.');
+    }
 
-  return impersonating;
+    return impersonating;
 }
 
 // Lots of ways of trying to find the user's email
@@ -66,24 +66,24 @@ function tryEmail() {
 }
 
 function getUserId(id) {
-  // If logged in, always identify by user email
-  if (isLoggedIn()) {
-    return global.__env.user.tf_login;
-  }
+    // If logged in, always identify by user email
+    if (isLoggedIn()) {
+        return global.__env.user.tf_login;
+    }
 
-  // Trust hawk to supply a valid ID, but nobody else
-  if (app() == 'hawk' && id) {
-    // Keep Hawk-supplied ID
-    return id;
-  }
+    // Trust hawk to supply a valid ID, but nobody else
+    if (app() == 'hawk' && id) {
+        // Keep Hawk-supplied ID
+        return id;
+    }
 
-  // If logged out, set the id to the mixpanel ID,
-  if (is.function(get(window, 'mixpanel.get_distinct_id'))) {
-    return window.mixpanel.get_distinct_id();
-  }
+    // If logged out, set the id to the mixpanel ID,
+    if (is.function(get(window, 'mixpanel.get_distinct_id'))) {
+        return window.mixpanel.get_distinct_id();
+    }
 
-  // If we can't find mixpanel, fallback to null ID
-  return null;
+    // If we can't find mixpanel, fallback to null ID
+    return null;
 }
 
 // Failsafe for if segment breaks for some reason

--- a/src/analytics/actions.es6
+++ b/src/analytics/actions.es6
@@ -233,7 +233,7 @@ function track(event, properties, options, fn) {
 
     properties = defaults(properties || {}, localInfo, appInfo(), get(global, '__env.user', {}), urlParams);
 
-    if (has(global, 'analytics.initialize')) {
+    if (get(global, 'analytics.initialize')) {
         global.analytics.track(event, properties, options, fn);
     } else {
         fallback(fn, {

--- a/src/analytics/actions.es6
+++ b/src/analytics/actions.es6
@@ -15,9 +15,13 @@ const cookies = zipObject(map(document.cookie.split('; '), function(cookie) {
     return [name, decodeURIComponent(value)];
 }));
 
+function app() {
+  return get(global, '__env.config.app.name', '').toLowerCase();
+}
+
 function appInfo() {
   return {
-      app: get(global, '__env.config.app.name', '').toLowerCase(),
+      app: app(),
       appDisplayName: get(global, '__env.config.app.displayName', '').toLowerCase(),
       uiAnalytics: true
   }
@@ -68,7 +72,7 @@ function getUserId(id) {
   }
 
   // Trust hawk to supply a valid ID, but nobody else
-  if (appInfo().app == 'hawk' && id) {
+  if (app() == 'hawk' && id) {
     // Keep Hawk-supplied ID
     return id;
   }
@@ -203,7 +207,7 @@ function alias(to, from, options, fn) {
     }
 
     // See Mixpanel rules in identify function
-    if (appInfo().app != 'tailorbird' && appInfo().app != 'pelican') {
+    if (app() != 'tailorbird' && app() != 'pelican') {
         log('Alias should only be called on account creation, or email capture.');
         return;
     }

--- a/src/analytics/actions.es6
+++ b/src/analytics/actions.es6
@@ -240,6 +240,15 @@ function track(event, properties, options, fn) {
     if (get(global, 'analytics.initialize')) {
         global.analytics.track(event, properties, options, fn);
     } else {
+        // Wait until the document has loaded so we can reliably check if
+        // Segment is actually blocked, or just still loading.
+        if (document.readyState !== 'complete') {
+            document.onreadystatechange = function() {
+                track(event, properties, options, fn);
+            }
+            return;
+        }
+
         fallback(fn, {
             'user_id': getUserId(),
             'call': 'track',


### PR DESCRIPTION
- Instead of `__env` and `appInfo` being consts, source them from the most up-to-date versions.
- Only use directly imported lodash functions.
- Tested with Pelican and it worked, but review closely since the changes are very spread out.