### PR TITLE
Tf-Guest signins see unauthed version of navbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkful-ui",
-  "version": "2.0.44",
+  "version": "2.0.45",
   "description": "Shared navigation and UI resources for Thinkful.",
   "main": "src/index.es6",
   "scripts": {

--- a/src/AppBar/Navigation.jsx
+++ b/src/AppBar/Navigation.jsx
@@ -250,7 +250,7 @@ class AppNav extends React.Component {
     render() {
         const {user, config} = this.props;
 
-        return user && user.tf_login ?
+        return user && user.tf_login && user.role !== 'guest' ?
             this.renderAuthed(user, config) : this.renderUnauthed(config);
     }
 }


### PR DESCRIPTION
Tf-Guest signins are "Authenticated" so they have a `window.__env.user`, meaning AppBar will try to show the logged-in version.  Luckily `role !== 'guest'` will discriminate. 
