### PR TITLE
allow dropdown to accept simple array

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkful-ui",
-  "version": "2.0.53",
+  "version": "2.0.54",
   "description": "Shared navigation and UI resources for Thinkful.",
   "main": "src/index.es6",
   "scripts": {

--- a/src/Dropdown/Dropdown.jsx
+++ b/src/Dropdown/Dropdown.jsx
@@ -16,7 +16,10 @@ require('./dropdown.less');
 const Dropdown = React.createClass({
 
   propTypes: {
-    data: React.PropTypes.array.isRequired,
+    data: React.PropTypes.arrayOf(
+      React.PropTypes.oneOfType([
+        React.PropTypes.string, React.PropTypes.object
+      ])).isRequired,
     initialSelectedInd: React.PropTypes.number,
     selectedInd: React.PropTypes.number,
     defaultDisplay: React.PropTypes.string,
@@ -46,15 +49,22 @@ const Dropdown = React.createClass({
   },
 
   _generateNodes() {
-    const {data} = this.props;
+    let {data} = this.props;
+
+    if (data.length && !data[0].value) {
+      data = data.map(item => {
+        return {value: item, displayName: item}
+      });
+    }
+
     return data.map((item, ind) => {
       return (
         <p
           className={cx("dropdown-item", item.className)}
           id={ind}
           key={ind}
-          value={item.value || item}>
-          {item.displayName || item}
+          value={item.value}>
+          {item.displayName}
         </p>
       );
     });
@@ -78,21 +88,8 @@ const Dropdown = React.createClass({
       return selectedInd || initialSelectedInd;
     }
 
-    // Case 2: no data provided
-    if (!data.length) {
-      return -1;
-    }
-
-    if (typeof(data[0]) === "object") {
-      // Case 3: data is array of objects with {displayName: 'foo', value: 'bar'}
-      const values = data.map(item => item.value);
-    }
-    else {
-      // Case 4: data is array of values
-      const values = data;
-    }
-
-    return data.indexOf(value);
+    // Case 2: get index of `value` from data array
+    return _.map(data, item => item.value || item).indexOf(value)
   },
 
   _getDisplayText() {
@@ -103,11 +100,8 @@ const Dropdown = React.createClass({
       return defaultDisplay;
     }
 
-    if (typeof(data[0]) === "object") {
-      return data[selectedInd] && data[selectedInd].displayName || defaultDisplay;
-    }
-
-    return data[selectedInd]
+    return _.map(data,
+      item => item.displayName || item)[selectedInd] || defaultDisplay;
   },
 
   render() {

--- a/src/Dropdown/Dropdown.jsx
+++ b/src/Dropdown/Dropdown.jsx
@@ -51,11 +51,14 @@ const Dropdown = React.createClass({
   _generateNodes() {
     let {data} = this.props;
 
-    if (data.length && !data[0].value) {
-      data = data.map(item => {
-        return {value: item, displayName: item}
-      });
-    }
+    // Translate `data` from an array of strings, if necessary.
+    data = data.map(item => {
+      return {
+        value: item.value || item,
+        displayName: item.displayName || item,
+        className: item.className,
+      }
+    });
 
     return data.map((item, ind) => {
       return (

--- a/src/Dropdown/Dropdown.jsx
+++ b/src/Dropdown/Dropdown.jsx
@@ -70,24 +70,52 @@ const Dropdown = React.createClass({
     handleChange(event);
   },
 
-  componentClickAway() {
-    this.setState({open: false});
+  _determineSelectedInd() {
+    const { data, initialSelectedInd, selectedInd, value } = this.props;
+
+    // Case 1: selectedInd or initialSelectedInd provided by props
+    if (selectedInd || initialSelectedInd) {
+      return selectedInd || initialSelectedInd;
+    }
+
+    // Case 2: no data provided
+    if (!data.length) {
+      return -1;
+    }
+
+    if (typeof(data[0]) === "object") {
+      // Case 3: data is array of objects with {displayName: 'foo', value: 'bar'}
+      const values = data.map(item => item.value);
+    }
+    else {
+      // Case 4: data is array of values
+      const values = data;
+    }
+
+    return data.indexOf(value);
+  },
+
+  _getDisplayText() {
+    const { data, defaultDisplay } = this.props;
+    const selectedInd = this._determineSelectedInd();
+
+    if (selectedInd === -1) {
+      return defaultDisplay;
+    }
+
+    if (typeof(data[0]) === "object") {
+      return data[selectedInd] && data[selectedInd].displayName || defaultDisplay;
+    }
+
+    return data[selectedInd]
   },
 
   render() {
-    let {
-      className,
-      data,
-      defaultDisplay,
-      initialSelectedInd,
-      selectedInd,
-    } = this.props;
-
-    selectedInd = selectedInd === undefined ? initialSelectedInd : selectedInd;
+    const { className } = this.props;
 
     const dropdownClasses = cx(
       'dd-open',
-      {'hidden': !this.state.open});
+      {hidden: !this.state.open});
 
     return (
       <div className={cx("dropdown-container", className)}>
@@ -97,7 +125,7 @@ const Dropdown = React.createClass({
             ref={c => this.dropdownButton = c}
             data-clickable>
           <span className="dropdown-text">
-            {data[selectedInd] && data[selectedInd].displayName || defaultDisplay}
+            {this._getDisplayText()}
           </span>
           <span className="icon-navigatedown" aria-hidden="true"></span>
         </div>

--- a/src/Dropdown/Dropdown.jsx
+++ b/src/Dropdown/Dropdown.jsx
@@ -53,8 +53,8 @@ const Dropdown = React.createClass({
           className={cx("dropdown-item", item.className)}
           id={ind}
           key={ind}
-          value={item.value}>
-          {item.displayName}
+          value={item.value || item}>
+          {item.displayName || item}
         </p>
       );
     });
@@ -76,8 +76,12 @@ const Dropdown = React.createClass({
 
   render() {
     let {
-      initialSelectedInd, selectedInd, data,
-      defaultDisplay, className} = this.props;
+      className,
+      data,
+      defaultDisplay,
+      initialSelectedInd,
+      selectedInd,
+    } = this.props;
 
     selectedInd = selectedInd === undefined ? initialSelectedInd : selectedInd;
 
@@ -92,7 +96,9 @@ const Dropdown = React.createClass({
             onClick={this._toggleOpen}
             ref={c => this.dropdownButton = c}
             data-clickable>
-          <span className="dropdown-text">{data[selectedInd] && data[selectedInd].displayName || defaultDisplay}</span>
+          <span className="dropdown-text">
+            {data[selectedInd] && data[selectedInd].displayName || defaultDisplay}
+          </span>
           <span className="icon-navigatedown" aria-hidden="true"></span>
         </div>
         <div


### PR DESCRIPTION
The `Dropdown` component previously accepted an array of objects for data, along with a `selectedInd` for the selected item ala:
```
data = [
  {'value': 1, 'displayName': 'foo'},
  {'value': 2, 'displayName': 'bar'}];
```

This PR allows it to accept just a simple array of strings and assumes that those strings should be both the value and display name for each item.  It also now accepts a `value` prop, which will replace `selectedInd` so that you don't need to search for the index outside of the component