### PR TITLE
Making Dropdown More Accessible

### DIFF
--- a/client/DemoPage.jsx
+++ b/client/DemoPage.jsx
@@ -23,7 +23,7 @@ class DemoPage extends React.Component {
     const sampleDropdownData = [{
       label:'Foods',
       options:[
-        { value: 'pizza', displayName: "Tasty Pizza"},
+        { value: 'pizza', displayName: "Super Tasty Pizza", label:"Tasty Pizza"},
         { value: 'waffles', displayName: "Delicious Waffles"},
         { value: 'felafel', displayName: "I'm feelin Falafel"}
       ]
@@ -44,7 +44,7 @@ class DemoPage extends React.Component {
         options:['Trail Blazers','Kings']
       },{
         label:'Football',
-        options:['49ers','Raiders'] 
+        options:['49ers','Raiders']
       }]
     }
     ];

--- a/client/DemoPage.jsx
+++ b/client/DemoPage.jsx
@@ -20,11 +20,33 @@ require('./styles/demo.less')
 
 class DemoPage extends React.Component {
   render() {
-    const sampleDropdownData = [
-      { value: 'pizza', displayName: "Tasty Pizza"},
-      { value: 'waffles', displayName: "Delicious Waffles"},
-      { value: 'felafel', displayName: "I'm feelin Falafel"},
-      { value: 'bose', displayName: "No highs no lows, must be Bose"}
+    const sampleDropdownData = [{
+      label:'Foods',
+      options:[
+        { value: 'pizza', displayName: "Tasty Pizza"},
+        { value: 'waffles', displayName: "Delicious Waffles"},
+        { value: 'felafel', displayName: "I'm feelin Falafel"}
+      ]
+    },
+    { value: 'react', displayName: "React", selected:true},
+    { value: 'angular', displayName: "AngularJS"},
+    { value: 'bose', displayName: "No highs no lows, must be Bose"},
+    {
+      label:'States',
+      options:[
+        'California','Oregon','New York'
+      ]
+    },
+    {
+      label:'Sports',
+      options:[{
+        label:'Basketball',
+        options:['Trail Blazers','Kings']
+      },{
+        label:'Football',
+        options:['49ers','Raiders'] 
+      }]
+    }
     ];
 
     const sampleNotifications = [
@@ -97,9 +119,9 @@ class DemoPage extends React.Component {
             target={Dropdown}
             props={{
               data: Demo.props.constant(sampleDropdownData),
-              initialSelectedInd: Demo.props.choices([undefined,0,1,2]),
-              defaultDisplay: Demo.props.string("Choose something awesome"),
-              handleChange: Demo.props.callback.log(e => e.target.getAttribute('value'))
+              handleChange: Demo.props.callback.log(e => e.target.value),
+              label:Demo.props.string("Choose something awesome"),
+              indentation:Demo.props.string("")
             }} />
 
           <h3>DatePicker</h3>

--- a/client/DemoPage.jsx
+++ b/client/DemoPage.jsx
@@ -46,7 +46,9 @@ class DemoPage extends React.Component {
         label:'Football',
         options:['49ers','Raiders']
       }]
-    }
+    },
+    'Bacon',
+    'Cheese'
     ];
 
     const sampleNotifications = [

--- a/src/Dropdown/Dropdown.jsx
+++ b/src/Dropdown/Dropdown.jsx
@@ -90,6 +90,7 @@ const Dropdown = React.createClass({
         <option
           id={data.ind}
           key={data.ind}
+          label={data.item.label}
           selected={data.item.selected}
           value={data.item.value}>
           {data.item.displayName}

--- a/src/Dropdown/Dropdown.jsx
+++ b/src/Dropdown/Dropdown.jsx
@@ -39,16 +39,16 @@ const Dropdown = React.createClass({
     let {data} = this.props;
     let {indentation} = this.props;
 
-    return data.map((item, ind) => (
-      makeOptions(item,ind,0)
+    return data.map((item) => (
+      makeOptions(item,0)
     ));
 
-    function makeOptions(item,ind,depth) {
+    function makeOptions(item,depth) {
       let items = [];
 
-      if(item.options !== undefined) {
+      if(_.has(item, 'options')) {
         var optionsDOM = item.options.map((item, ind) => (
-          makeOptions(item,ind,depth + 1)
+          makeOptions(item,depth + 1)
         ));
         var indent = '';
         for(var i = 0; i < depth; i++) indent += indentation;
@@ -59,43 +59,42 @@ const Dropdown = React.createClass({
         );
       }
 
-      if(typeof(item) !== 'object') { // it is a string
+      if(_.isString(item)) { // it is a string
         items.push({
           item:{
-            value:item,
+            value:cssSafe(item),
             displayName:item
-          },ind:ind
+          }
         });
       } else {
-        if(item.length !== undefined) { // it is an Array
-          for(var i = 0; i < item.length; i++) {
+        if(_.isArray(item)) { // it is an Array of strings
+          _.each(item, function(item) {
             items.push({
               item:{
-                value:item[i],
-                displayName:item[i]
-              },
-              ind:ind.toString() + '-' + i.toString()
+                value:cssSafe(item),
+                displayName:item
+              }
             });
-          }
-        } else { // it is an Object
-          items.push({
-            item:item,
-            ind:ind
-          });
+          })
+        } else { // it is a simple Object
+          items.push({ item:item });
         }
       }
 
       // one or more options
       return items.map((data) => (
         <option
-          id={data.ind}
-          key={data.ind}
+          key={data.item.value}
           label={data.item.label}
           selected={data.item.selected}
           value={data.item.value}>
           {data.item.displayName}
         </option>
       ));
+
+      function cssSafe(name) {
+        return name.toLowerCase().replace(/[!\"#$%&'\(\)\*\+,\.\/:;<=>\?\@\[\\\]\^`\{\|\}~]/g, '');
+      }
     }
   },
 

--- a/src/Dropdown/Dropdown.jsx
+++ b/src/Dropdown/Dropdown.jsx
@@ -112,9 +112,11 @@ const Dropdown = React.createClass({
     return (
       <label>
         {label}
-        <select className={cx("dropdown-container", className)} onChange={this._handleChange} value={this.state.value}>
-          {this._generateNodes()}
-        </select>
+        <div className={cx("dropdown-container", className)}>
+          <select onChange={this._handleChange} value={this.state.value}>
+            {this._generateNodes()}
+          </select>
+        </div>
       </label>
     );
   }

--- a/src/Dropdown/dropdown.less
+++ b/src/Dropdown/dropdown.less
@@ -4,6 +4,25 @@
   width: 420px;
   max-width: 100%;
   position: relative;
+  &:after {
+    font-family: icomoon;
+    speak: none;
+    font-style: normal;
+    font-weight: 400;
+    font-variant: normal;
+    text-transform: none;
+    line-height: 1;
+    vertical-align: middle;
+    font-size: 20px;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+
+    content: "\f501";
+    position: absolute;
+    right: 1em;
+    top: 15px;
+    pointer-events: none;
+  }
 }
 
 .dropdown-text {


### PR DESCRIPTION
Makes `<Dropdown>` more accessibleBy using native `<select>`, `<optgroup>`, and `<option>`.
- Now more keyboard accessible (supports "typeahead") and arrow keys to navigate.
- Screen Reader friendly.
- Supports nested optgroups (kinda).  

Closes Thinkful/ui#314

_Note: Build files are not checked in. Please run `webpack` after `git pull`._
### Pros
- Accessibility
- Keyboard control
- Native UX (mobile)
- more red than green (-90 + 71)
### Cons
- Can't style `<option>`

![](http://j4p.us/1V18141H2L1O/Screen%20Shot%202016-06-09%20at%206.42.39%20PM.png)
### Example Data

Data can be `optgroup` wrapper objects which contain `label` and `options` properties, simple option objects which contain `value`, `displayName` properties and an optional `selected` property, or a simple array of strings.

_Note: There is an `indentation` optional property if you'd like to "indent" nested `<optgroup>`s. Also note that `<optgroup>`s can't really be nested, hence the need to simulate it using indentation. To disable set indentation to an empty string._

``` js
[{
  label:'Foods',
  options:[
    { value: 'pizza', displayName: "Tasty Pizza"},
    { value: 'waffles', displayName: "Delicious Waffles"},
    { value: 'felafel', displayName: "I'm feelin Falafel"}
  ]
},
{ value: 'react', displayName: "React", selected:true},
{ value: 'angular', displayName: "AngularJS"},
{ value: 'bose', displayName: "No highs no lows, must be Bose"},
{
  label:'States',
  options:[
    'California','Oregon','New York'
  ]
},
{
  label:'Sports',
  options:[{
    label:'Basketball',
    options:['Trail Blazers','Kings']
  },{
    label:'Football',
    options:['49ers','Raiders']
  }]
}
]
```
