### PR TITLE
Update getstream to 3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "eslint-loader": "^0.12.0",
     "extract-text-webpack-plugin": "^0.8.1",
     "file-loader": "^0.8.4",
-    "getstream": "^2.2.2",
+    "getstream": "^3.4.0",
     "history": "^1.13.1",
     "html-loader": "^0.3.0",
     "is_js": "^0.8.0",

--- a/src/AppBar/notifications/NotificationActions.es6
+++ b/src/AppBar/notifications/NotificationActions.es6
@@ -50,7 +50,7 @@ const processFetch = function (refetch, error, response, body) {
         time: "2015-09-23T03:17:30.280968"
         verb: "request-nps"
     */
-    
+
     if (refetch) {
       NotificationActions.fetchNotifications();
     }


### PR DESCRIPTION
[faye 1.2.0](https://github.com/faye/faye/releases/tag/1.2.0) appears to break semver (though unsure how). The upgrade from `getstream` 2.x to 3.x looks like an in-place upgrade for us.

We use the following methods:
- `stream.connect` (option with api key and app key)
- `client.feed`
- `feed.get` (with options `limit`, `mark_seen`, and `mark_read`)
all of which remain the same between 2.x and 3.x

`getstream` 3.4 pins faye at 1.2.0

[:metal:🎶](https://www.youtube.com/watch?v=LYU-8IFcDPw) I can't faye...the way I did before! Don't break semver on me! I won't be ignored! [🎶:metal:](https://www.youtube.com/watch?v=LYU-8IFcDPw)