### PR TITLE
date picker improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkful-ui",
-  "version": "2.0.89",
+  "version": "2.0.90",
   "description": "Shared navigation and UI resources for Thinkful.",
   "main": "src/index.es6",
   "scripts": {

--- a/src/DatePicker/DatePicker.jsx
+++ b/src/DatePicker/DatePicker.jsx
@@ -111,12 +111,10 @@ class DatePicker extends React.Component {
   }
 
   _checkClickAway(event) {
-    const buttonDomNode = ReactDOM.findDOMNode(this.dropdownButton)
-    const calendarDomNode = ReactDOM.findDOMNode(this.calendar)
     // Close the picker if the click wasn't on the dropdown button or calendar
     if (
-        (buttonDomNode && !buttonDomNode.contains(event.target)) &&
-        (calendarDomNode && !calendarDomNode.contains(event.target))) {
+        (this.dropdownButton && !this.dropdownButton.contains(event.target)) &&
+        (this.calendar && !this.calendar.contains(event.target))) {
       this.setState({visible: false});
     }
   }

--- a/src/DatePicker/DatePicker.jsx
+++ b/src/DatePicker/DatePicker.jsx
@@ -3,6 +3,7 @@ const ReactDOM = require('react-dom')
 const moment = require('moment-timezone');
 const cx = require('classnames');
 const _ = require('lodash');
+const { Icon } = require('../Icon')
 
 require('./datepicker.less');
 
@@ -161,14 +162,14 @@ class DatePicker extends React.Component {
             onClick={this._toggleOpen.bind(this)}
             ref={c => this.dropdownButton = c}>
           {!value && placeholder ? placeholder : moment(activeDay).format('MM/DD/YYYY')}
-          <span className="icon-navigatedown" aria-hidden="true"></span>
+          <Icon name="navigatedown" />
         </div>
         <div className={datePickerClasses} ref={c => this.calendar = c}>
-          <span
-              className="icon-navigateleft" aria-hidden="true"
+          <Icon
+              name="navigateleft"
               onClick={this._navigateBack.bind(this)} />
-          <span
-              className="icon-navigateright" aria-hidden="true"
+          <Icon
+              name="navigateright"
               onClick={this._navigateForward.bind(this)} />
           <div className="selected-day">
             {moment(activeDay).format('dddd, MMMM Do')}

--- a/src/DatePicker/DatePicker.jsx
+++ b/src/DatePicker/DatePicker.jsx
@@ -110,8 +110,12 @@ class DatePicker extends React.Component {
   }
 
   _checkClickAway(event) {
-    const domNode = ReactDOM.findDOMNode(this.dropdownButton)
-    if (domNode && !domNode.contains(event.target)) {
+    const buttonDomNode = ReactDOM.findDOMNode(this.dropdownButton)
+    const calendarDomNode = ReactDOM.findDOMNode(this.calendar)
+    // Close the picker if the click wasn't on the dropdown button or calendar
+    if (
+        (buttonDomNode && !buttonDomNode.contains(event.target)) &&
+        (calendarDomNode && !calendarDomNode.contains(event.target))) {
       this.setState({visible: false});
     }
   }
@@ -159,13 +163,13 @@ class DatePicker extends React.Component {
           {!value && placeholder ? placeholder : moment(activeDay).format('MM/DD/YYYY')}
           <span className="icon-navigatedown" aria-hidden="true"></span>
         </div>
-        <div className={datePickerClasses}>
-        <span
-            className="icon-navigateleft" aria-hidden="true"
-            onClick={this._navigateBack.bind(this)}></span>
-        <span
-            className="icon-navigateright" aria-hidden="true"
-            onClick={this._navigateForward.bind(this)}></span>
+        <div className={datePickerClasses} ref={c => this.calendar = c}>
+          <span
+              className="icon-navigateleft" aria-hidden="true"
+              onClick={this._navigateBack.bind(this)} />
+          <span
+              className="icon-navigateright" aria-hidden="true"
+              onClick={this._navigateForward.bind(this)} />
           <div className="selected-day">
             {moment(activeDay).format('dddd, MMMM Do')}
           </div>


### PR DESCRIPTION
Some improvements to the `DatePicker` -
- defaults to "today" as the active day if none passed
- dropdown closes when you click somewhere else on the screen
- supports displaying a placeholder value in the dropdown until a date is picked (such as "Select a date", etc)
- use thinkful ui `Icon` component