### PR TITLE
HTML-ify the Dropdown component

### DIFF
--- a/client/DemoPage.jsx
+++ b/client/DemoPage.jsx
@@ -99,7 +99,7 @@ class DemoPage extends React.Component {
               data: Demo.props.constant(sampleDropdownData),
               initialSelectedInd: Demo.props.choices([undefined,0,1,2]),
               defaultDisplay: Demo.props.string("Choose something awesome"),
-              handleChange: Demo.props.callback.log(e => e.target.getAttribute('value'))
+              handleChange: Demo.props.callback.log(e => e.target.value)
             }} />
 
           <h3>DatePicker</h3>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkful-ui",
-  "version": "2.0.93",
+  "version": "2.0.94",
   "description": "Shared navigation and UI resources for Thinkful.",
   "main": "src/index.es6",
   "scripts": {

--- a/src/Dropdown/Dropdown.jsx
+++ b/src/Dropdown/Dropdown.jsx
@@ -34,20 +34,6 @@ const Dropdown = React.createClass({
     return {data: []};
   },
 
-  componentDidMount() {
-    document.addEventListener('click', this._checkClickAway);
-  },
-
-  componentWillUnmount() {
-    document.removeEventListener('click', this._checkClickAway);
-  },
-
-  _checkClickAway(e) {
-    if (!ReactDOM.findDOMNode(this.dropdownButton).contains(e.target)) {
-      this.setState({open: false});
-    }
-  },
-
   _generateNodes() {
     let {data} = this.props;
 
@@ -62,24 +48,18 @@ const Dropdown = React.createClass({
 
     return data.map((item, ind) => {
       return (
-        <p
-          className={cx("dropdown-item", item.className)}
-          id={ind}
+        <option
+          className={cx(item.className)}
           key={ind}
           value={item.value}>
           {item.displayName}
-        </p>
+        </option>
       );
     });
   },
 
-  _toggleOpen() {
-    this.setState({open: !this.state.open});
-  },
-
   _handleChange(event) {
     let {handleChange} = this.props;
-    this._toggleOpen();
     handleChange(event);
   },
 
@@ -99,44 +79,22 @@ const Dropdown = React.createClass({
     return _.map(data, item => item.value || item).indexOf(value)
   },
 
-  _getDisplayText() {
-    const { data, defaultDisplay } = this.props;
-    const selectedInd = this._determineSelectedInd();
-
-    if (selectedInd === -1) {
-      return defaultDisplay;
-    }
-
-    return _.map(data,
-      item => item.displayName || item)[selectedInd] || defaultDisplay;
-  },
-
   render() {
-    const { className } = this.props;
+    const { className, defaultDisplay } = this.props;
 
     const dropdownClasses = cx(
-      'dd-open',
-      {hidden: !this.state.open});
+      "tui-dropdown-container",
+      dropdownClasses);
 
-    return (
-      <div className={cx("dropdown-container", className)}>
-        <div
-            className="button dd-button"
-            onClick={this._toggleOpen}
-            ref={c => this.dropdownButton = c}
-            data-clickable>
-          <span className="dropdown-text">
-            {this._getDisplayText()}
-          </span>
-          <span className="icon-navigatedown" aria-hidden="true"></span>
-        </div>
-        <div
-          className={dropdownClasses}
-          onClick={this._handleChange}>
-          {this._generateNodes()}
-        </div>
-      </div>
-    );
+    const selectedInd = this._determineSelectedInd();
+
+    return <div className={dropdownClasses}>
+      <select onChange={e => this._handleChange(e)} className="tui-dropdown">
+        {selectedInd == -1 &&
+          <option selected disabled key="tui-dropdown-default">{defaultDisplay}</option>}
+        {this._generateNodes()}
+      </select>
+    </div>;
   }
 });
 

--- a/src/Dropdown/Dropdown.jsx
+++ b/src/Dropdown/Dropdown.jsx
@@ -10,8 +10,10 @@ require('./dropdown.less');
  * @property data {Array} of items to display in the dropdown,
       containing `value` and `displayName`
  * @property selectedInd {Int} of the selected index in the list
+ * @property initialSelectedInd {Int} first element that should be selected
  * @property defaultDisplay {String} of default value that should be displayed
  * @property handleChange {Function} to handle dropdown click/change
+ * @property htmlId {String} html id for label
  */
 const Dropdown = React.createClass({
 
@@ -23,7 +25,8 @@ const Dropdown = React.createClass({
     initialSelectedInd: React.PropTypes.number,
     selectedInd: React.PropTypes.number,
     defaultDisplay: React.PropTypes.string,
-    handleChange: React.PropTypes.func.isRequired
+    handleChange: React.PropTypes.func.isRequired,
+    htmlId: React.PropTypes.string,
   },
 
   getInitialState() {
@@ -80,7 +83,7 @@ const Dropdown = React.createClass({
   },
 
   render() {
-    const { className, defaultDisplay } = this.props;
+    const { htmlId, className, defaultDisplay } = this.props;
 
     const dropdownClasses = cx(
       "tui-dropdown-container",
@@ -89,7 +92,10 @@ const Dropdown = React.createClass({
     const selectedInd = this._determineSelectedInd();
 
     return <div className={dropdownClasses}>
-      <select onChange={e => this._handleChange(e)} className="tui-dropdown">
+      <select
+        id={htmlId}
+        onChange={e => this._handleChange(e)}
+        className="tui-dropdown">
         {selectedInd == -1 &&
           <option selected disabled key="tui-dropdown-default">{defaultDisplay}</option>}
         {this._generateNodes()}

--- a/src/Dropdown/Dropdown.jsx
+++ b/src/Dropdown/Dropdown.jsx
@@ -52,7 +52,7 @@ const Dropdown = React.createClass({
     return data.map((item, ind) => {
       return (
         <option
-          className={cx(item.className)}
+          className={item.className}
           key={ind}
           value={item.value}>
           {item.displayName}
@@ -93,9 +93,9 @@ const Dropdown = React.createClass({
 
     return <div className={dropdownClasses}>
       <select
-        id={htmlId}
-        onChange={e => this._handleChange(e)}
-        className="tui-dropdown">
+          id={htmlId}
+          onChange={e => this._handleChange(e)}
+          className="tui-dropdown">
         {selectedInd == -1 &&
           <option selected disabled key="tui-dropdown-default">{defaultDisplay}</option>}
         {this._generateNodes()}

--- a/src/Dropdown/dropdown.less
+++ b/src/Dropdown/dropdown.less
@@ -1,70 +1,25 @@
 @import '~tfstyleguide/vars';
 
-.dropdown-container {
+.tui-dropdown-container {
+  position: relative;
   width: 420px;
   max-width: 100%;
   position: relative;
-}
 
-.dropdown-text {
-  pointer-events: none;
-}
-
-.button.dd-button {
-  width: 100%;
-  position: relative;
-  border: 1px solid mix(@gray25, @gray50, 70%);
-  box-shadow: inset 0px 3px 7px @gray15;
-  background-color: @white;
-  line-height: 28px;
-  color: @gray75;
-  margin-bottom: 0;
-
-  &:focus, &:hover, &:active, &:visited {
-    outline: none;
-    background-color: @gray15;
-    color: @black;
-  }
-
-  .icon-navigatedown {
+  &:after {
+    content: '\f501';
+    font-family: 'icomoon';
+    line-height: 1;
     position: absolute;
-    right: 1em;
-    top: 15px;
-    pointer-events: none;
+    right: 15px;
+    top: 14px;
+    font-size: 20px;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 }
 
-.dd-open {
-  max-height: 300px;
-  overflow: scroll;
-  border: 1px solid @gray25;
-  border-radius: 3px;
-  background-color: @gray15;
-  position: absolute;
-  max-width: 100%;
+.tui-dropdown {
   width: 100%;
-  cursor: pointer;
-  z-index: 10;
-
-  p {
-    color: @gray75;
-    font-size: 16px;
-    padding-top: 7px;
-    padding-bottom: 8px;
-    padding-left: 1em;
-    padding-right: 1em;
-    margin-bottom: 0;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-
-    &:hover {
-      background-color: @blue25;
-      color: @blue;
-    }
-  }
 }
 
-.hidden {
-  display: none;
-}

--- a/src/Dropdown/dropdown.less
+++ b/src/Dropdown/dropdown.less
@@ -1,11 +1,11 @@
 @import '~tfstyleguide/vars';
 
 .tui-dropdown-container {
+  display: inline-block;
   position: relative;
   margin-top: 15px;
   width: 420px;
   max-width: 100%;
-  position: relative;
 
   &:after {
     content: '\f501';

--- a/src/Dropdown/dropdown.less
+++ b/src/Dropdown/dropdown.less
@@ -2,6 +2,7 @@
 
 .tui-dropdown-container {
   position: relative;
+  margin-top: 15px;
   width: 420px;
   max-width: 100%;
   position: relative;


### PR DESCRIPTION
Improves usability / accessibility of the dropdown component.

Retains existing API for the component, adds label-friendly `id` option.

JP's original edition: https://github.com/Thinkful/ui/pull/315