### PR TITLE
fix(analytics): stop mixpanel dups

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkful-ui",
-  "version": "2.0.95",
+  "version": "2.0.96",
   "description": "Shared navigation and UI resources for Thinkful.",
   "main": "src/index.es6",
   "scripts": {


### PR DESCRIPTION
Fix on .identify
---------------

Fix on .identify stops us from sending an email trait to an anonymous
profile. This causes duplicates in both mixpanel and heap, as a
profile whose id is still a UUID gets an email. This doesn't make sense
since we could technically create several of these "unaliased" profiles
for the same person, and wouldn't be able to merge them at any point.

The expected outcome is that identify will be called with the email,
forcing the anonymous profile to be dettached in Mixpanel (we lose
history) and forcing a creation of a profile with that email.

Heap should merge the anonymous history instead of "orphaning" it.

Fix on .alias
------------
Fix on .alias prevents the AnalyticsAPI object from aliasing users
already identified as profile with an email, to a different email,
triggering an identity call instead.

This should cause less duplicates and weird issues in Mixpanel, even
collecting the rare anonymous session that gets all the way to stork,
and should help Heap merge histories together (suspicion is Heap just
ignores alias calls as that's not part of their API).