### PR TITLE
Fix typo and add link to student activity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkful-ui",
-  "version": "2.0.99",
+  "version": "2.0.100",
   "description": "Shared navigation and UI resources for Thinkful.",
   "main": "src/index.es6",
   "scripts": {

--- a/src/OpenSessionOverview/OpenSessionOverview.jsx
+++ b/src/OpenSessionOverview/OpenSessionOverview.jsx
@@ -81,14 +81,18 @@ class OpenSessionOverview extends React.Component {
   }
 
   _renderGravatars() {
-    return this.props.participants.map((p, idx) => {
+    const {config, participants} = this.props;
+
+    return participants.map((p, idx) => {
       return (
         <div className="qa-session-participants__item" key={idx}>
-          <Gravatar
-            className="gravatar-image__participant"
-            src={p.image_url}
-            email={p.email}/>
-          <div>{p.name}</div>
+          <a href={`${config.activity.url}/student/${p.user_id}`}>
+            <Gravatar
+              className="gravatar-image__participant"
+              src={p.image_url}
+              email={p.email}/>
+            <div>{p.name}</div>
+          </a>
         </div>
       )
     });
@@ -197,7 +201,7 @@ class OpenSessionOverview extends React.Component {
             }
           </div>
           <div>
-            {user && (user.role === 'admin' || session.isUserHost(user)) && session.session_type === 'qa_session' && this._participantList()}
+            {user && (user.role === 'admin' || session.userIsHost(user)) && session.session_type === 'qa_session' && this._participantList()}
           </div>
         </div>
       </div>

--- a/src/OpenSessionOverview/OpenSessionOverview.jsx
+++ b/src/OpenSessionOverview/OpenSessionOverview.jsx
@@ -86,7 +86,7 @@ class OpenSessionOverview extends React.Component {
     return participants.map((p, idx) => {
       return (
         <div className="qa-session-participants__item" key={idx}>
-          <a href={`${config.activity.url}/student/${p.user_id}`}>
+          <a href={`${config.dashboard.url}/student/${p.user_id}`}>
             <Gravatar
               className="gravatar-image__participant"
               src={p.image_url}


### PR DESCRIPTION
Fixes a typo that was breaking open-sessions page:

![image](https://user-images.githubusercontent.com/1640757/27104389-1d148db2-505a-11e7-8a41-c84a7ac01705.png)

Since I was editing `ui` I made another improvement to my previous changes