### PR TITLE
Prop types 1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4677,6 +4677,27 @@
         "websocket-driver": "0.7.0"
       }
     },
+    "fbjs": {
+      "version": "0.8.16",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+      "requires": {
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.17"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        }
+      }
+    },
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -9621,27 +9642,6 @@
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-        },
-        "fbjs": {
-          "version": "0.8.16",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
-          "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
-          "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.17"
-          }
-        }
       }
     },
     "proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "moment-timezone": "^0.4.0",
     "node-libs-browser": "^0.5.2",
     "node-notifier": "^4.2.1",
+    "prop-types": "^15.6.0",
     "qs": "^5.2.0",
     "react": "^15.0",
     "react-avatar-editor": "^3.2.0",

--- a/src/Gravatar.jsx
+++ b/src/Gravatar.jsx
@@ -1,37 +1,30 @@
 const cx = require('classnames');
+const PropTypes = require('prop-types');
 const React = require('react');
 const MD5 = require('spark-md5');
 
 const URL = 'https://www.gravatar.com/avatar';
 
-/**
- * Gravatar
- * @property {string} email the users email to use with gravatar
- */
-class Gravatar extends React.Component {
-    static displayName = "Gravatar"
+const Gravatar = ({ className, style, email, size, ...props }) => (
+  <img
+    className={cx('gravatar', className)}
+    src={`${URL}/${MD5.hash(email)}?d=${this.props.default}&s=${size}`}
+    style={style || {}}
+    {...props} />
+)
 
-    static propTypes = {
-        email: React.PropTypes.string.isRequired,
-        default: React.PropTypes.string,
-        size: React.PropTypes.number,
-        style: React.PropTypes.object
-    }
+Gravatar.propTypes = {
+  email: PropTypes.string.isRequired,
+  default: PropTypes.string,
+  size: PropTypes.number,
+  style: PropTypes.object
+}
 
-    static defaultProps = {
-        default: 'retro',
-        size: 200,
-        style: {}
-    }
-
-    render() {
-        const {className, style, email='', size, ...props} = this.props;
-        return <img
-            className={cx("gravatar", className)}
-            src={`${URL}/${MD5.hash(email)}?d=${this.props.default}&s=${size}`}
-            style={style || {}}
-            {...props}/>
-    }
+Gravatar.defaultProps = {
+  default: 'retro',
+  email: '',
+  size: 200,
+  style: {}
 }
 
 module.exports = Gravatar;

--- a/src/Icon.jsx
+++ b/src/Icon.jsx
@@ -1,26 +1,20 @@
+const PropTypes = require('prop-types')
 const React = require('react');
 
-/**
- * Icon
- * @property {String} name  the icon class to use
- */
-class Icon extends React.Component {
-    static displayName = "Icon"
+const Icon = ({ className, name, ...props }) => (
+  <span
+    aria-hidden='true'
+    className={`tui-icon icon-${name} ${className}`}
+    {...props}
+  />
+)
 
-    static propTypes = {
-        name: React.PropTypes.string.isRequired
-    }
+Icon.propTypes = {
+  name: PropTypes.string.isRequired
+}
 
-    render() {
-        const {name='pizza', className='', ...props} = this.props;
-        return (
-            <span
-                aria-hidden='true'
-                className={`tui-icon icon-${name} ${className}`}
-                {...props}
-            />
-        )
-    }
+Icon.defaultProps = {
+  name: 'pizza',
 }
 
 module.exports = Icon;

--- a/src/OneClickCopy/OneClickCopy.jsx
+++ b/src/OneClickCopy/OneClickCopy.jsx
@@ -1,21 +1,8 @@
 const cx = require('classnames');
+const PropTypes = require('prop-types');
 const React = require('react');
 
 class OneClickCopy extends React.Component {
-  static propTypes = {
-    className: React.PropTypes.oneOfType(
-            [React.PropTypes.string, React.PropTypes.object]),
-    copyButtonText: React.PropTypes.string,
-    inputText: React.PropTypes.string,
-    onCopyClick: React.PropTypes.func,
-    onCopyClickSuccess: React.PropTypes.func,
-    onCopyClickFail: React.PropTypes.func,
-  }
-
-  static defaultProps = {
-    copyButtonText: 'Copy'
-  }
-
   _handleInputClick = (event) => {
     event.preventDefault();
     this.inputElement.select();
@@ -58,4 +45,20 @@ class OneClickCopy extends React.Component {
   }
 }
 
-module.exports = OneClickCopys
+OneClickCopy.propTypes = {
+  className: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.string,
+  ]),
+  copyButtonText: PropTypes.string,
+  inputText: PropTypes.string,
+  onCopyClick: PropTypes.func,
+  onCopyClickSuccess: PropTypes.func,
+  onCopyClickFail: PropTypes.func,
+}
+
+OneClickCopy.defaultProps = {
+  copyButtonText: 'Copy'
+}
+
+module.exports = OneClickCopy

--- a/src/OpenSessionOverview/OpenSessionOverview.jsx
+++ b/src/OpenSessionOverview/OpenSessionOverview.jsx
@@ -1,8 +1,9 @@
 const cx = require('classnames');
-const Link = require('react-router').Link;
-const moment = require('moment-timezone');
-const React = require('react');
 const _ = require('lodash');
+const moment = require('moment-timezone');
+const PropTypes = require('prop-types');
+const React = require('react');
+const { Link } = require('react-router');
 
 const Gravatar = require('../Gravatar');
 const Icon = require('../Icon');
@@ -10,20 +11,22 @@ const Tag = require('../Tag');
 
 const FALLBACK_QA_DESCRIPTION = 'Have questions? Get answers! Check out the topic tags to the right. If you see one that fits your question, feel free to hop in the session. You can stay for the full hour or just long enough to get your answer. Ask about projects, concepts, or the industry.'
 
-class OverviewContent extends React.Component {
-  render() {
-    const {session} = this.props;
-    const {description, host, title} = session;
-    return (
-      <div className="overview-content">
-        <h3 className="title" itemProp="name">{title}</h3>
-        <p className="host-name">with {host.name}</p>
-        <p className="overview-description" itemProp="description">
-          {description || FALLBACK_QA_DESCRIPTION}
-        </p>
-      </div>
-      );
-  }
+const OverviewContent = ({ session: { description, host, title } }) => (
+  <div className="overview-content">
+    <h3 className="title" itemProp="name">{title}</h3>
+    <p className="host-name">with {host.name}</p>
+    <p className="overview-description" itemProp="description">
+      {description || FALLBACK_QA_DESCRIPTION}
+    </p>
+  </div>
+);
+
+OverviewContent.propTypes = {
+  session: PropTypes.shape({
+    description: PropTypes.string.isRequired,
+    host: PropTypes.shape({ name: PropTypes.string.isRequired }),
+    title: PropTypes.string.isRequired,
+  }).isRequired
 }
 
 /**
@@ -32,39 +35,15 @@ class OverviewContent extends React.Component {
 class OpenSessionOverview extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      requestPending: false
-    }
+
     this._renderQASessionCtas = this._renderQASessionCtas.bind(this);
     this._renderWorkshopCta = this._renderWorkshopCta.bind(this);
     this._shouldRenderMobile = this._shouldRenderMobile.bind(this);
     this._handleRSVPButtonClick = this._handleRSVPButtonClick.bind(this);
-  }
 
-  static displayName = "OpenSessionOverview"
-
-  static propTypes = {
-    attending: React.PropTypes.bool,
-    config: React.PropTypes.object,
-    handleCancelRSVPClick: React.PropTypes.func,
-    handleRSVPClick: React.PropTypes.func,
-    handleCancelSessionClick: React.PropTypes.func,
-    handleCancelAllSessionsClick: React.PropTypes.func,
-    handleEditSessionClick: React.PropTypes.func,
-    hosting: React.PropTypes.bool,
-    previewing: React.PropTypes.bool,
-    session: React.PropTypes.object.isRequired,
-    participants: React.PropTypes.array,
-    user: React.PropTypes.object
-  }
-
-  static defaultProps = {
-    attending: false,
-    hosting: false,
-    linkToCalendar: false,
-    previewing: false,
-    participants: [],
-    tags: []
+    this.state = {
+      requestPending: false
+    }
   }
 
   _shouldRenderMobile() {
@@ -314,6 +293,30 @@ class OpenSessionOverview extends React.Component {
       </div>
       )
   }
+}
+
+OpenSessionOverview.propTypes = {
+  attending: PropTypes.bool,
+  config: PropTypes.object,
+  handleCancelRSVPClick: PropTypes.func,
+  handleRSVPClick: PropTypes.func,
+  handleCancelSessionClick: PropTypes.func,
+  handleCancelAllSessionsClick: PropTypes.func,
+  handleEditSessionClick: PropTypes.func,
+  hosting: PropTypes.bool,
+  previewing: PropTypes.bool,
+  session: PropTypes.object.isRequired,
+  participants: PropTypes.array,
+  user: PropTypes.object
+}
+
+OpenSessionOverview.defaultProps = {
+  attending: false,
+  hosting: false,
+  linkToCalendar: false,
+  previewing: false,
+  participants: [],
+  tags: []
 }
 
 module.exports = OpenSessionOverview;

--- a/src/SearchBar/SearchActions.js
+++ b/src/SearchBar/SearchActions.js
@@ -2,9 +2,8 @@ const Reflux = require('reflux');
 const superagent = require('superagent');
 
 const SearchActions = Reflux.createActions({
-  getSuggestions: {asyncResult: true}
+   getSuggestions: { asyncResult: true }
 });
-
 
 SearchActions.getSuggestions.listen(function(input, config) {
   const fetchURLBase = config.useSSL ?
@@ -20,6 +19,5 @@ SearchActions.getSuggestions.listen(function(input, config) {
       : this.failed(error || response);
     });
 });
-
 
 module.exports = SearchActions

--- a/src/SearchBar/SearchBar.jsx
+++ b/src/SearchBar/SearchBar.jsx
@@ -1,4 +1,5 @@
 const React = require('react');
+const PropTypes = require('prop-types');
 const cx = require('classnames');
 
 const Icon = require('../Icon');
@@ -9,12 +10,6 @@ const UP_ARROW_KEY_CODE = 38;
 const ENTER_KEY_CODE = 13;
 
 class SearchBar extends React.Component {
-  static defaultProps = {
-    underlay: false,
-    heading: false,
-    open: false
-  }
-
   constructor(props) {
     super(props);
     this.state = {
@@ -99,7 +94,7 @@ class SearchBar extends React.Component {
   }
 
   _handleClickAway = (event) => {
-    const {handleClickAway} = this.props;
+    const { handleClickAway } = this.props;
     handleClickAway(event);
   }
 
@@ -165,14 +160,14 @@ class SearchBar extends React.Component {
     if (event) {
       event.preventDefault();
     }
-    const {config} = this.props;
+    const { config } = this.props;
 
     window.location = `${config.projects.url}/search?q=${
       encodeURIComponent(this.state.searchTerm)}`;
   }
 
   render() {
-    const {active, className, config, heading, underlay, open} = this.props;
+    const { active, className, config, heading, underlay, open } = this.props;
     const {
       inputClassName, searchTerm, selectedSuggestionIdx, suggestions
     } = this.state;
@@ -227,6 +222,19 @@ class SearchBar extends React.Component {
       </div>
       )
   }
+}
+
+SearchBar.propTypes = {
+  handleClickAway: PropTypes.func,
+  heading: PropTypes.bool,
+  open: PropTypes.bool,
+  underlay: PropTypes.bool,
+}
+
+SearchBar.defaultProps = {
+  underlay: false,
+  heading: false,
+  open: false
 }
 
 module.exports = SearchBar

--- a/src/Sidebar/Layout.jsx
+++ b/src/Sidebar/Layout.jsx
@@ -1,30 +1,20 @@
 const React = require('react');
+const PropTypes = require('prop-types');
 const classnames = require('classnames');
 
-/**
- *  Base layout for pages that have a sidebar element.
- *  @property sidebarMenu {Component} to go in the sidebar
- */
-class SidebarLayout extends React.Component {
-  static propTypes = {
-    sidebarMenu: React.PropTypes.element
-  }
+const SidebarLayout = ({ sidebarMenu }) => (
+  <div className="sidebar-layout-container">
+    <div className="sidebar-layout-sidebar">
+      {sidebarMenu}
+    </div>
+    <div className="sidebar-layout-main">
+      {this.props.children}
+    </div>
+  </div>
+);
 
-  render() {
-    const {sidebarMenu} = this.props;
-
-    return (
-      <div className="sidebar-layout-container">
-        <div className="sidebar-layout-sidebar">
-          {sidebarMenu}
-        </div>
-        <div className="sidebar-layout-main">
-          {this.props.children}
-        </div>
-      </div>
-    );
-  }
+SidebarLayout.propTypes = {
+  sidebarMenu: PropTypes.element
 }
-
 
 module.exports = SidebarLayout;

--- a/src/Sidebar/Menu.jsx
+++ b/src/Sidebar/Menu.jsx
@@ -1,31 +1,21 @@
 const React = require('react');
+const PropTypes = require('prop-types');
 const classnames = require('classnames');
 
-/**
- *  Menu element for sidebar
- *  @property heading {String} of the heading to display above the menu
- *  @property items {Array} of components to include in the menu
- */
-class SidebarMenu extends React.Component {
-  static propTypes = {
-    heading: React.PropTypes.string,
-    items: React.PropTypes.arrayOf(React.PropTypes.component)
-  }
+const SidebarMenu = ({ heading, items }) => (
+  <div className="sidebar-menu">
+    <div className="subheading">{heading}</div>
+    {items}
+  </div>
+)
 
-  static defaultProps = {
-    items: []
-  }
+SidebarMenu.propTypes = {
+  heading: PropTypes.string,
+  items: PropTypes.arrayOf(PropTypes.component)
+}
 
-  render() {
-    const {heading, items} = this.props;
-
-    return (
-      <div className="sidebar-menu">
-        <div className="subheading">{heading}</div>
-        {items}
-      </div>
-    );
-  }
+SidebarMenu.defaultProps = {
+  items: []
 }
 
 module.exports = SidebarMenu;

--- a/src/Sidebar/MenuItem.jsx
+++ b/src/Sidebar/MenuItem.jsx
@@ -1,35 +1,28 @@
 const React = require('react');
-const classnames = require('classnames');
+const PropTypes = require('prop-types');
+const cx = require('classnames');
 
 const Icon = require('../Icon');
 
-/**
- *  Menu item element
- *  @property classes {String/Object/Array} of classes
- *  @property isActive {Boolean} indictaing if the item is currently active
- */
-class MenuItem extends React.Component {
-  static propTypes = {
-    classes: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.object,
-        React.PropTypes.array
-      ]),
-    isActive: React.PropTypes.bool
-  }
+const MenuItem = ({ classes, isActive, handleClick }) => (
+  <div
+      className={cx(
+        classes,
+        'menu-item',
+        { 'menu-item__active': isActive })}
+      onClick={handleClick}>
+    <Icon name="navigateright" />
+    {this.props.children}
+  </div>
+);
 
-  render() {
-    const {classes, isActive, handleClick} = this.props;
-    const itemClasses = classnames(classes, 'menu-item', {'menu-item__active': isActive});
-
-    return (
-      <div className={itemClasses} onClick={handleClick}>
-        <Icon name="navigateright"/>
-        {this.props.children}
-      </div>
-    );
-  }
+MenuItem.propTypes = {
+  classes: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.array,
+  ]),
+  isActive: PropTypes.bool
 }
-
 
 module.exports = MenuItem;

--- a/src/Sidebar/index.js
+++ b/src/Sidebar/index.js
@@ -1,9 +1,5 @@
-const SidebarMenu = require('./Menu');
-const SidebarMenuItem = require('./MenuItem')
-const SidebarLayout = require('./Layout');
-
 module.exports = {
-    SidebarLayout,
-    SidebarMenu,
-    SidebarMenuItem
+  SidebarLayout: require('./Layout'),
+  SidebarMenu: require('./Menu'),
+  SidebarMenuItem: require('./MenuItem'),
 };

--- a/src/SocialShare/SocialShare.jsx
+++ b/src/SocialShare/SocialShare.jsx
@@ -1,4 +1,5 @@
 const cx = require('classnames');
+const PropTypes = require('prop-types');
 const React = require('react');
 
 /**
@@ -6,11 +7,6 @@ const React = require('react');
   a social share link.  Currently supports facebook, twitter and linked in.
  */
 class SocialShare extends React.Component {
-  static propTypes = {
-    type: React.PropTypes.oneOf(['facebook', 'twitter', 'linkedin']),
-    handleTrackClick: React.PropTypes.func
-  }
-
   _openSocialShareWindow = (width, height, location) => {
     window.open(location, '',
       `menubar=no,toolbar=no,resizable=yes,scrollbars=yes,` +
@@ -57,6 +53,11 @@ class SocialShare extends React.Component {
       {this.props.children}
     </div>
   }
+}
+
+SocialShare.propTypes = {
+  type: PropTypes.oneOf(['facebook', 'twitter', 'linkedin']),
+  handleTrackClick: PropTypes.func
 }
 
 module.exports = SocialShare

--- a/src/Tag/Tag.jsx
+++ b/src/Tag/Tag.jsx
@@ -1,34 +1,27 @@
 const cx = require('classnames');
+const PropTypes = require('prop-types');
 const React = require('react');
 
 const NOOP = () => {};
 
-class Tag extends React.Component {
+const Tag = ({ children, className, displayName, onClick, url }) => (
+  <a
+      className={cx("tui-tag", className)}
+      href={url}
+      onClick={onClick}>
+    {displayName}
+    {children}
+  </a>
+)
 
-  static displayName = 'Tag'
+Tag.propTypes = {
+  className: PropTypes.string,
+  displayName: PropTypes.string,
+  url: PropTypes.string
+}
 
-  static propTypes = {
-    className: React.PropTypes.string,
-    displayName: React.PropTypes.string,
-    url: React.PropTypes.string
-  }
-
-  static defaultProps = {
-    onClick: NOOP
-  }
-
-  render() {
-    const {children, className, displayName, onClick, url} = this.props;
-    return (
-      <a
-          className={cx("tui-tag", className)}
-          href={url}
-          onClick={onClick}>
-        {displayName}
-        {children}
-      </a>
-      )
-  }
+Tag.defaultProps = {
+  onClick: NOOP
 }
 
 module.exports = Tag

--- a/src/TopicPicker/TopicPicker.jsx
+++ b/src/TopicPicker/TopicPicker.jsx
@@ -87,8 +87,7 @@ class TopicPicker extends React.Component {
         if (addMatchEmphasis) {
           const firstIndex = topic
             .toLowerCase()
-            .indexOf(topic.toLowerCase()
-            .match(normalizedPattern)[0])
+            .indexOf(topic.toLowerCase().match(normalizedPattern)[0])
           const lastIndex = firstIndex + pattern.length + 1;
 
           let topicArray = topic.split('');

--- a/src/TopicPicker/TopicPicker.jsx
+++ b/src/TopicPicker/TopicPicker.jsx
@@ -1,6 +1,7 @@
 const cx = require('classnames');
 const escapeStringRegexp = require('escape-string-regexp');
 const marked = require('marked');
+const PropTypes = require('prop-types');
 const React = require('react');
 
 const Icon = require('../Icon');
@@ -12,6 +13,8 @@ const COMMA_KEY_CODE = 188;
 const RETURN_KEY_CODE = 13;
 
 const DEFAULT_MIN_TOPIC_LENGTH = 1;
+
+const mapLower = v => v.toLowerCase()
 
 /*
  * TopicPicker component
@@ -29,48 +32,76 @@ const DEFAULT_MIN_TOPIC_LENGTH = 1;
  * @property {Number} minTopicLength The min length a topic string must be
  */
 class TopicPicker extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
+
+    // Private methods
+    this._filterTopicList = this._filterTopicList.bind(this)
+    this._handleKeyDown = this._handleKeyDown.bind(this)
+    this._handleMoveSelected = this._handleMoveSelected.bind(this)
+    this._handlePatternChange = this._handlePatternChange.bind(this)
+    this._handleAddTopic = this._handleAddTopic.bind(this)
+    this._handleRemoveTopic = this._handleRemoveTopic.bind(this)
+    this._handleTopicSubmit = this._handleTopicSubmit.bind(this)
+    this._toggleFocus = this._toggleFocus.bind(this)
+
+    // Public methods
+    this.getTopics = this.getTopics.bind(this)
+
     this.state = {
       pattern: '',
-      topics: [],
+      topics: props.activeTopics,
       selectedSuggestionIndex: -1
     };
   }
 
-  static displayName = 'TopicPicker'
-
-  static propTypes = {
-    activeTopics: React.PropTypes.array,
-    availableTopics: React.PropTypes.array,
-    addMatchEmphasis: React.PropTypes.bool,
-    className: React.PropTypes.string,
-    handleUpdateTopics: React.PropTypes.func,
-    maxSuggestions: React.PropTypes.number,
-    minTopicLength: React.PropTypes.number,
-  }
-
-  static defaultProps = {
-    availableTopics: [],
-    activeTopics: [],
-    maxSuggestions: 10,
-    minTopicLength: DEFAULT_MIN_TOPIC_LENGTH,
-    placeholderText: "Add a tag (hit 'return' after each one)",
-    // if parent doesn't pass in callback, to avoid conditionals inline
-    handleUpdateTopics: () => null,
-  }
-
-  componentDidMount() {
-    const {activeTopics} = this.props;
-    this.setState({topics: activeTopics});
-  }
-
   componentWillReceiveProps(newProps) {
-    const {activeTopics} = newProps;
-    this.setState({topics: activeTopics});
+    this.setState({ topics: newProps.activeTopics });
   }
 
-  _handleKeyDown = (event) => {
+  /*
+   * Return the `availableTopics`, filtered for a matching pattern
+   *
+   * This makes the topics markdown to add emphasis if the property
+   * `addMatchEmphasis` is truthy.
+   */
+  _filterTopicList (additionalTopics) {
+    const { addMatchEmphasis, availableTopics, maxSuggestions } = this.props;
+    const { pattern, topics } = this.state;
+
+    // in case topic is something like `C++`
+    const normalizedPattern = escapeStringRegexp(
+      this.state.pattern.toLowerCase());
+
+    // find and mark the pattern matches in a case-insensitive way
+    return availableTopics
+      // filter for matching available topics
+      .filter(topic => (
+        topic.toLowerCase().match(normalizedPattern) &&
+        topics.indexOf(topic) < 0
+      )).
+      // limit the number of results
+      .slice(0, maxSuggestions).
+      // add the asterisks for emphasis around matching area
+      .map(topic => {
+        if (addMatchEmphasis) {
+          const firstIndex = topic
+            .toLowerCase()
+            .indexOf(topic.toLowerCase()
+            .match(normalizedPattern)[0])
+          const lastIndex = firstIndex + pattern.length + 1;
+
+          let topicArray = topic.split('');
+          topicArray.splice(firstIndex, 0, '*')
+          topicArray.splice(lastIndex, 0, '*')
+
+          return topicArray.join('');
+        }
+        return topic
+      })
+  }
+
+  _handleKeyDown (event) {
     const {selectedSuggestionIndex} = this.state;
     const suggestions = this._filterTopicList();
 
@@ -96,9 +127,9 @@ class TopicPicker extends React.Component {
    *
    * Usable in keydown handler for moving selected topic in suggestion list
    */
-  _handleMoveSelected = (numMoves) => {
-    const {availableTopics} = this.props;
-    const {selectedSuggestionIndex} = this.state;
+  _handleMoveSelected (numMoves) {
+    const { availableTopics } = this.props;
+    const { selectedSuggestionIndex } = this.state;
     const newSelectedIndex = selectedSuggestionIndex + numMoves
 
     if (newSelectedIndex >= -1 && newSelectedIndex < (availableTopics || []).length) {
@@ -109,59 +140,21 @@ class TopicPicker extends React.Component {
   /*
    * Handler for a form change
    */
-  _handlePatternChange = (event) => {
+  _handlePatternChange (event) {
     this.setState({pattern: event.target.value})
-  }
-
-  /*
-   * Return the `availableTopics`, filtered for a matching pattern
-   *
-   * This makes the topics markdown to add emphasis if the property
-   * `addMatchEmphasis` is truthy.
-   */
-  _filterTopicList = (additionalTopics) => {
-    const {topics, pattern} = this.state;
-    // in case topic is something like `C++`
-    const normalizedPattern = escapeStringRegexp(
-      this.state.pattern.toLowerCase());
-
-    const {availableTopics, addMatchEmphasis, maxSuggestions} = this.props;
-
-    // find and mark the pattern matches in a case-insensitive way
-    return (availableTopics).
-      filter(topic => { // filter for matching available topics
-        return topic.toLowerCase().match(normalizedPattern) &&
-               topics.indexOf(topic) < 0
-      }).
-      slice(0, maxSuggestions). // limit the number of results
-      map(topic => { // add the asterisks for emphasis around matching area
-        if (addMatchEmphasis) {
-          const firstIndex = topic.toLowerCase().
-            indexOf(topic.toLowerCase().match(normalizedPattern)[0])
-          const lastIndex = firstIndex + pattern.length + 1;
-
-          let topicArray = topic.split('');
-          topicArray.splice(firstIndex, 0, '*')
-          topicArray.splice(lastIndex, 0, '*')
-          return topicArray.join('');
-        }
-        else {
-          return topic
-        }
-      })
   }
 
   /*
    * Add a topic to the internal list of topics
    */
-  _handleAddTopic = (topic) => {
-    const {topics} = this.state;
-    const {handleUpdateTopics} = this.props;
+  _handleAddTopic (topic) {
+    const { topics } = this.state;
+    const { handleUpdateTopics } = this.props;
 
-    if (topics.map(t => t.toLowerCase()).indexOf(topic.toLowerCase()) < 0) {
+    if (topics.map(mapLower).indexOf(topic.toLowerCase()) < 0) {
       // We trim the whitespace off the tag before adding it
       let newTopics = topics.concat(topic.trim());
-      this.setState({topics: newTopics});
+      this.setState({ topics: newTopics });
       handleUpdateTopics(newTopics);
     }
 
@@ -173,20 +166,20 @@ class TopicPicker extends React.Component {
    *
    * Matching is case-sensitive
    */
-  _handleRemoveTopic = (topic) => {
-    const {topics} = this.state;
-    const {handleUpdateTopics} = this.props;
+  _handleRemoveTopic (topic) {
+    const { topics } = this.state;
+    const { handleUpdateTopics } = this.props;
 
     let newTopics = topics.filter(t => t !== topic);
 
-    this.setState({topics: newTopics});
+    this.setState({ topics: newTopics });
     handleUpdateTopics(newTopics);
   }
 
   /*
    * Handle submission of a new topic
    */
-  _handleTopicSubmit = (event) => {
+  _handleTopicSubmit (event) {
     if (event && event.preventDefault) {
       event.preventDefault();
     }
@@ -205,22 +198,21 @@ class TopicPicker extends React.Component {
     }
   }
 
-  _toggleFocus = () => {
-    this.setState({
-      isFocused: !this.state.isFocused
-    })
+  _toggleFocus () {
+    this.setState({ isFocused: !this.state.isFocused })
   }
 
   /*
    * Getter for topics
    */
-  getTopics() {
+  getTopics () {
     return this.state.topics;
   }
 
   render() {
-    const {pattern, topics, selectedSuggestionIndex, isFocused} = this.state;
-    const {className, placeholderText} = this.props;
+    const { className, placeholderText } = this.props;
+    const { isFocused, pattern, selectedSuggestionIndex, topics } = this.state;
+
     return (
       <div
         className={cx(
@@ -229,58 +221,71 @@ class TopicPicker extends React.Component {
           isFocused && 'topic-picker-focus')}>
 
         {/* The existing topics */}
-        {topics.map((topic, index) => {
-          return (
-            <Tag
-              key={index}
-              className='topic'
-              displayName={topic}>
-              <div
-                  className="topic-delete-button"
-                  onClick={(event) => this._handleRemoveTopic(topic)}>
-                <Icon name="close"/>
-              </div>
-            </Tag>
-          );
-        })}
+        {topics.map((topic, index) => (
+          <Tag
+            key={index}
+            className='topic'
+            displayName={topic}>
+            <div
+                className="topic-delete-button"
+                onClick={(event) => this._handleRemoveTopic(topic)}>
+              <Icon name="close"/>
+            </div>
+          </Tag>
+        ))}
 
         <div
             className="topic-form"
             onKeyDown={this._handleKeyDown}
             onSubmit={this._handleTopicSubmit}>
           <input
-              onFocus={this._toggleFocus}
-              onBlur={this._toggleFocus}
-              className="topic-form-input"
-              type="text"
-              value={pattern}
-              placeholder={placeholderText}
-              onChange={this._handlePatternChange}/>
+            onFocus={this._toggleFocus}
+            onBlur={this._toggleFocus}
+            className="topic-form-input"
+            type="text"
+            value={pattern}
+            placeholder={placeholderText}
+            onChange={this._handlePatternChange} />
 
           {/* The list of topic suggestions */}
           {pattern && (
             <ul className="topic-suggestion-list">
-              {this._filterTopicList().map((topic, index) => {
-                return (
-                  <li
+              {this._filterTopicList().map((topic, index) => (
+                <li
                     key={index}
                     className={cx(
                       'topic-list-item',
-                      {selected: index === selectedSuggestionIndex})
-                    }
-                    onClick={(event) => this._handleAddTopic(
-                      topic.replace(/\*/g, ''))
-                    }
-                    dangerouslySetInnerHTML={{__html: marked(topic)}}/>
-                );
-              })}
+                      { selected: index === selectedSuggestionIndex })}
+                    onClick={(event) =>
+                      this._handleAddTopic(topic.replace(/\*/g, ''))}
+                    dangerouslySetInnerHTML={{__html: marked(topic)}} />
+              ))}
             </ul>
-            )
-          }
+          )}
         </div>
       </div>
     );
   }
+}
+
+TopicPicker.propTypes = {
+  activeTopics: PropTypes.array,
+  availableTopics: PropTypes.array,
+  addMatchEmphasis: PropTypes.bool,
+  className: PropTypes.string,
+  handleUpdateTopics: PropTypes.func,
+  maxSuggestions: PropTypes.number,
+  minTopicLength: PropTypes.number,
+}
+
+TopicPicker.defaultProps = {
+  availableTopics: [],
+  activeTopics: [],
+  maxSuggestions: 10,
+  minTopicLength: DEFAULT_MIN_TOPIC_LENGTH,
+  placeholderText: "Add a tag (hit 'return' after each one)",
+  // if parent doesn't pass in callback, to avoid conditionals inline
+  handleUpdateTopics: () => null,
 }
 
 module.exports = TopicPicker

--- a/src/TopicPicker/TopicPicker.jsx
+++ b/src/TopicPicker/TopicPicker.jsx
@@ -79,9 +79,9 @@ class TopicPicker extends React.Component {
       .filter(topic => (
         topic.toLowerCase().match(normalizedPattern) &&
         topics.indexOf(topic) < 0
-      )).
+      ))
       // limit the number of results
-      .slice(0, maxSuggestions).
+      .slice(0, maxSuggestions)
       // add the asterisks for emphasis around matching area
       .map(topic => {
         if (addMatchEmphasis) {

--- a/src/TrackedLink/TrackedLink.jsx
+++ b/src/TrackedLink/TrackedLink.jsx
@@ -1,5 +1,6 @@
 const log = require('debug')('ui:analytics');
 const omit = require('lodash/object/omit');
+const PropTypes = require('prop-types');
 const React = require('react');
 const TFAnalytics = require('@thinkful/tf-analytics');
 
@@ -23,43 +24,53 @@ const TFAnalytics = require('@thinkful/tf-analytics');
  *  }
  */
 class TrackedLink extends React.Component {
-    static propTypes = {
-        data: React.PropTypes.object,
-        href: React.PropTypes.string.isRequired,
-        type: React.PropTypes.string
-    }
+  constructor(props) {
+    super(props)
 
-    static defaultProps = {
-        type: 'link'
-    }
+    this._handleClick = this._handleClick.bind(this)
+  }
 
-    _handleClick(event) {
-        let data = omit(this.props, 'children', 'className', 'href', 'target');
-        data = {url: this.props.href, ...data};
-        let eventName = `clicked-${global.__env.config.appDisplayName}-${this.props.type}`;
-        log(eventName, data);
+  _handleClick(event) {
+    const data = omit(
+      this.props,
+      'children',
+      'className',
+      'href',
+      'onClick',
+      'target');
+    data.url = this.props.href
 
-        TFAnalytics.track(eventName, data);
+    let eventName = `clicked-${global.__env.config.appDisplayName}-${this.props.type}`;
 
-        this.props.onClick &&
-            this.props.onClick(event);
-    }
+    log(eventName, data);
+    TFAnalytics.track(eventName, data);
 
-    render() {
-        const {children, className, href, onClick, ...props} = this.props;
+    this.props.onClick && this.props.onClick(event);
+  }
 
-        return (
-            <a
-                className={className}
-                href={href}
-                onClick={event => this._handleClick(event)}
-                {...props}
-            >
-                {children}
-            </a>
-        )
-    }
+  render() {
+    const { children, className, href, ...props } = this.props;
 
+    return (
+      <a
+          className={className}
+          href={href}
+          onClick={this._handleClick}
+          {...props}>
+        {children}
+      </a>
+    )
+  }
+}
+
+TrackedLink.propTypes = {
+  data: PropTypes.object,
+  href: PropTypes.string.isRequired,
+  type: PropTypes.string
+}
+
+TrackedLink.defaultProps = {
+  type: 'link'
 }
 
 module.exports = TrackedLink;


### PR DESCRIPTION
- Start migrating to the `prop-types` package instead of `React.PropTypes`
- Some linting of files

No functional changes

`PropTypes` were pulled out of the react package and removed in React 16, so before upgrading, this needs to be changed

As far as linting goes, some components are getting changed to the lighter functional style and `stage-0` features are being replaced. We shouldn't be using these features, because they're not guaranteed to be a part of future releases