### PR TITLE
supress call to stream API for DS users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkful-ui",
-  "version": "6.0.13",
+  "version": "6.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkful-ui",
-  "version": "6.0.14",
+  "version": "6.0.15",
   "description": "Shared UI resources for Thinkful.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/AppBar/notifications/NotificationActions.jsx
+++ b/src/AppBar/notifications/NotificationActions.jsx
@@ -1,17 +1,34 @@
 const Reflux = require('reflux');
 const stream = require('getstream');
 const _ = require('lodash');
+
 const CONFIG = global.__env ? global.__env.config : null;
 const USER = global.__env ? global.__env.user : null;
+const DESIGN_SYS_FLAG = 'design-system';
+const LIMIT = 5;
+
 const NotificationActions = Reflux.createActions({
   fetchNotifications: { asyncResult: true },
   markSeen: { asyncResult: true },
   markRead: { asyncResult: true },
   processEvent: { asyncResult: true },
 });
+
 let client = null;
 let userFeed = null;
-if (CONFIG && CONFIG.vendor.getstream.userFeedToken) {
+
+const shouldInitNotifications = () => {
+  // Initialize notifications if we have the token in config and the user
+  // is not on the design system
+  return (
+    CONFIG &&
+    USER &&
+    CONFIG.vendor.getstream.userFeedToken &&
+    USER.access.indexOf(DESIGN_SYS_FLAG) === -1
+  )
+}
+
+if (shouldInitNotifications()) {
   client = stream.connect(
     CONFIG.vendor.getstream.apiKey,
     null,
@@ -22,9 +39,8 @@ if (CONFIG && CONFIG.vendor.getstream.userFeedToken) {
     (USER ? USER.contact_id : 1).toString(),
     CONFIG.vendor.getstream.userFeedToken,
   );
-} else {
 }
-const LIMIT = 5;
+
 const processFetch = function(refetch, error, response, body) {
   if (!response || response.status === 200) {
     let unread = body.unread;
@@ -67,10 +83,12 @@ const processFetch = function(refetch, error, response, body) {
     this.failed(error);
   }
 };
+
 NotificationActions.fetchNotifications.listen(function() {
   if (!userFeed) return;
   userFeed.get({ limit: LIMIT }, processFetch.bind(this, false));
 });
+
 NotificationActions.markSeen.listen(function(markSeen) {
   if (!userFeed) return;
   userFeed.get(
@@ -78,6 +96,7 @@ NotificationActions.markSeen.listen(function(markSeen) {
     processFetch.bind(this, true),
   );
 });
+
 NotificationActions.markRead.listen(function(markRead) {
   if (!userFeed) return;
   userFeed.get(
@@ -85,6 +104,7 @@ NotificationActions.markRead.listen(function(markRead) {
     processFetch.bind(this, true),
   );
 });
+
 NotificationActions.processEvent.listen(function(data) {
   console.log('Processing push event...', data);
   let unread = data.unread;
@@ -114,6 +134,7 @@ NotificationActions.processEvent.listen(function(data) {
     deleted: deleted,
   });
 });
+
 module.exports = {
   NotificationActions,
   userFeed,

--- a/src/AppBar/notifications/NotificationActions.jsx
+++ b/src/AppBar/notifications/NotificationActions.jsx
@@ -5,7 +5,7 @@ const _ = require('lodash');
 const CONFIG = global.__env ? global.__env.config : null;
 const USER = global.__env ? global.__env.user : null;
 const DESIGN_SYS_FLAG = 'design-system';
-const LIMIT = 5;
+const NOTIFICATION_LIMIT = 5;
 
 const NotificationActions = Reflux.createActions({
   fetchNotifications: { asyncResult: true },
@@ -23,7 +23,7 @@ const shouldInitNotifications = () => {
   return (
     CONFIG &&
     USER &&
-    CONFIG.vendor.getstream.userFeedToken &&
+    _.get(CONFIG, 'vendor.getstream.userFeedToken') &&
     USER.access.indexOf(DESIGN_SYS_FLAG) === -1
   )
 }
@@ -86,13 +86,13 @@ const processFetch = function(refetch, error, response, body) {
 
 NotificationActions.fetchNotifications.listen(function() {
   if (!userFeed) return;
-  userFeed.get({ limit: LIMIT }, processFetch.bind(this, false));
+  userFeed.get({ limit: NOTIFICATION_LIMIT }, processFetch.bind(this, false));
 });
 
 NotificationActions.markSeen.listen(function(markSeen) {
   if (!userFeed) return;
   userFeed.get(
-    { limit: LIMIT, mark_seen: markSeen },
+    { limit: NOTIFICATION_LIMIT, mark_seen: markSeen },
     processFetch.bind(this, true),
   );
 });
@@ -100,7 +100,7 @@ NotificationActions.markSeen.listen(function(markSeen) {
 NotificationActions.markRead.listen(function(markRead) {
   if (!userFeed) return;
   userFeed.get(
-    { limit: LIMIT, mark_read: markRead },
+    { limit: NOTIFICATION_LIMIT, mark_read: markRead },
     processFetch.bind(this, true),
   );
 });


### PR DESCRIPTION
We're reaching our API limit with stream, which we use for the nav bar notifications.  Design system users don't get those notifications, we should suppress any calls to the API for them