### PR TITLE
dont make a request if the contactId is undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkful-ui",
-  "version": "6.0.29",
+  "version": "6.0.30",
   "description": "Shared UI resources for Thinkful.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/AppBar/currentEnrollment.js
+++ b/src/AppBar/currentEnrollment.js
@@ -1,6 +1,10 @@
 import superagent from 'superagent';
 
 const getCurrentEnrollment = (config, user, successCallback, failCallback) => {
+  if (user.contactId === undefined) {
+    return;
+  }
+
   const url = `${config.api.url}/api/contacts/${user.contactId}/enrollments/current`;
   return superagent
     .get(url)


### PR DESCRIPTION
Funny thing!
This call is causing A BUNCH of 404 requests to pysplash: https://logentries.com/app/f5d9d6aa#/search/log/9fd341ea?log_q=where(status%3D404)&last=Last%2020%20Minutes

Funnier thing!
For 404s, pysplash makes a request to Pelican for the HTML of its 404 page.

Funniest thing!
This combination makes the 404 "endpoint" the 5th most time-consuming transaction in our API!
![image](https://user-images.githubusercontent.com/1640757/72461087-84dba800-37ce-11ea-8019-40ca2015ddca.png)
