### PR TITLE
add prep contact link to concierge modal

### DIFF
--- a/less/modules/app-bar.less
+++ b/less/modules/app-bar.less
@@ -339,9 +339,17 @@
   flex-direction: column;
 }
 
+.tui-concierge-option-link {
+  display: block;
+  margin: 8px 0 12px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
 .tui-concierge-option {
   height: 48px;
-  margin: 8px 0 12px;
   padding: 6px 8px;
   border-radius: 2px;
 
@@ -364,7 +372,7 @@
 .tui-concierge-contact {
   color: @gray75;
   font-size: 14px;
-  padding-top: 12px;
+  padding-top: 22px;
 
   a {
     font-family: 'MaisonNeue-Bold';

--- a/less/modules/app-bar.less
+++ b/less/modules/app-bar.less
@@ -212,7 +212,6 @@
   right: 16px;
   left: auto;
   min-width: 320px;
-  height: 420px; // nice
   border-radius: 2px;
   z-index: 5;
   transform: translate(0, @nav-height);
@@ -359,6 +358,18 @@
     font-size: 11px;
     color: @white;
     margin-bottom: 0;
+  }
+}
+
+.tui-concierge-contact {
+  color: @gray75;
+  font-size: 14px;
+  padding-top: 12px;
+
+  a {
+    font-family: 'MaisonNeue-Bold';
+    color: @gray75;
+    font-size: 14px;
   }
 }
 

--- a/src/AppBar/AppBar.jsx
+++ b/src/AppBar/AppBar.jsx
@@ -168,6 +168,7 @@ class AppBar extends React.Component {
       isMenuVisible,
       isConciergeVisible,
       isConciergeTooltipVisible,
+      isPrepUser,
       linkSet,
       slackUrl,
     } = this.state;
@@ -225,9 +226,10 @@ class AppBar extends React.Component {
           {_.includes(user.access, CONCIERGE_FLAG) && (
             <Fragment>
               <ConciergeModal
+                isPrepUser={true}
                 slackUrl={slackUrl}
-                visible={isConciergeVisible}
                 toggleConcierge={this._toggleConcierge}
+                visible={isConciergeVisible}
               />
               {this._shouldShowTooltip() && (
                 <ConciergeTooltip toggleConcierge={this._toggleConcierge} />

--- a/src/AppBar/AppBar.jsx
+++ b/src/AppBar/AppBar.jsx
@@ -226,7 +226,7 @@ class AppBar extends React.Component {
           {_.includes(user.access, CONCIERGE_FLAG) && (
             <Fragment>
               <ConciergeModal
-                isPrepUser={true}
+                isPrepUser={isPrepUser}
                 slackUrl={slackUrl}
                 toggleConcierge={this._toggleConcierge}
                 visible={isConciergeVisible}

--- a/src/AppBar/ConciergeModal.jsx
+++ b/src/AppBar/ConciergeModal.jsx
@@ -58,7 +58,7 @@ class ConciergeModal extends React.Component {
   }
 
   render() {
-    const { slackUrl, toggleConcierge } = this.props;
+    const { isPrepUser, slackUrl, toggleConcierge } = this.props;
     return (
       <div ref={this.wrapperRef}>
         <div className="tui-concierge-arrow" />
@@ -105,6 +105,13 @@ class ConciergeModal extends React.Component {
               link="https://thinkful.com/open-sessions/qa-sessions"
             />
           </div>
+
+          {isPrepUser && (
+            <div className='tui-concierge-contact'>
+              Have personal questions regarding your prep program? Email{' '}
+              <a href='mailto:prep@thinkful.com'>prep@thinkful.com</a> for help.
+            </div>
+          )}
         </div>
       </div>
     );
@@ -112,9 +119,14 @@ class ConciergeModal extends React.Component {
 }
 
 ConciergeModal.propTypes = {
+  isPrepUser: PropTypes.bool.isRequired,
   slackUrl: PropTypes.string,
-  visible: PropTypes.bool.isRequired,
   toggleConcierge: PropTypes.func.isRequired,
-}
+  visible: PropTypes.bool.isRequired,
+};
+
+ConciergeModal.defaultProps = {
+  slackUrl: null,
+};
 
 export default ConciergeModal;

--- a/src/AppBar/ConciergeOption.jsx
+++ b/src/AppBar/ConciergeOption.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { black } from '../styleguide';
 
 const ConciergeOption = ({ title, subtitle, link, background }) => (
-  <a href={link}>
+  <a href={link} className="tui-concierge-option-link">
     <div
       className="tui-concierge-option"
       style={{


### PR DESCRIPTION
With contact link:
![image](https://user-images.githubusercontent.com/7073794/74788777-8eda4600-5267-11ea-85bb-1399e189f084.png)

Original unchanged:
![image](https://user-images.githubusercontent.com/7073794/74788799-9ac60800-5267-11ea-8ff5-89c6a7c8e76a.png)

