### PR TITLE
T13562 Use snake case fallback when fetching enrollment.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkful-ui",
-  "version": "6.0.34",
+  "version": "6.0.35",
   "description": "Shared UI resources for Thinkful.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/AppBar/currentEnrollment.js
+++ b/src/AppBar/currentEnrollment.js
@@ -1,11 +1,12 @@
 import superagent from 'superagent';
 
 const getCurrentEnrollment = (config, user, successCallback, failCallback) => {
-  if (user.contactId === undefined) {
+  const contactId = user.contactId || user.contact_id;
+  if (contactId === undefined) {
     return;
   }
 
-  const url = `${config.api.url}/api/contacts/${user.contactId}/enrollments/current`;
+  const url = `${config.api.url}/api/contacts/${contactId}/enrollments/current`;
   return superagent
     .get(url)
     .withCredentials()


### PR DESCRIPTION
This is needed because non-Seagull apps inject a `user` object that uses snake_case, not camelCase. 

See https://phabricator.bloc.io/T13562